### PR TITLE
MAX values from the RFC specs should be set to infinite.

### DIFF
--- a/pyasn1_modules/rfc2437.py
+++ b/pyasn1_modules/rfc2437.py
@@ -26,8 +26,6 @@ id_mgf1 = univ.ObjectIdentifier('1.2.840.113549.1.1.8')
 id_pSpecified = univ.ObjectIdentifier('1.2.840.113549.1.1.9')
 id_sha1 = univ.ObjectIdentifier('1.3.14.3.2.26')
 
-MAX = 16
-
 
 class Version(univ.Integer):
     pass

--- a/pyasn1_modules/rfc2459.py
+++ b/pyasn1_modules/rfc2459.py
@@ -15,7 +15,7 @@
 #
 from pyasn1.type import tag, namedtype, namedval, univ, constraint, char, useful
 
-MAX = 64  # XXX ?
+MAX = float('inf')
 
 #
 # PKIX1Explicit88

--- a/pyasn1_modules/rfc2511.py
+++ b/pyasn1_modules/rfc2511.py
@@ -14,7 +14,7 @@
 from pyasn1_modules.rfc2459 import *
 from pyasn1_modules import rfc2315
 
-MAX = 16
+MAX = float('inf')
 
 id_pkix = univ.ObjectIdentifier('1.3.6.1.5.5.7')
 id_pkip = univ.ObjectIdentifier('1.3.6.1.5.5.7.5')

--- a/pyasn1_modules/rfc3280.py
+++ b/pyasn1_modules/rfc3280.py
@@ -14,7 +14,7 @@
 #
 from pyasn1.type import univ, char, namedtype, namedval, tag, constraint, useful
 
-MAX = 64
+MAX = float('inf')
 
 
 def _OID(*components):

--- a/pyasn1_modules/rfc3281.py
+++ b/pyasn1_modules/rfc3281.py
@@ -21,7 +21,7 @@ from pyasn1.type import useful
 
 from pyasn1_modules import rfc3280
 
-MAX = 64
+MAX = float('inf')
 
 
 def _buildOid(*components):

--- a/pyasn1_modules/rfc3852.py
+++ b/pyasn1_modules/rfc3852.py
@@ -16,7 +16,7 @@ from pyasn1.type import univ, namedtype, namedval, tag, constraint, useful
 from pyasn1_modules import rfc3280
 from pyasn1_modules import rfc3281
 
-MAX = 64
+MAX = float('inf')
 
 
 def _buildOid(*components):

--- a/pyasn1_modules/rfc4210.py
+++ b/pyasn1_modules/rfc4210.py
@@ -11,7 +11,7 @@
 from pyasn1.type import tag, namedtype, namedval, univ, constraint, char, useful
 from pyasn1_modules import rfc2459, rfc2511, rfc2314
 
-MAX = 64
+MAX = float('inf')
 
 
 class KeyIdentifier(univ.OctetString):

--- a/pyasn1_modules/rfc4211.py
+++ b/pyasn1_modules/rfc4211.py
@@ -17,7 +17,7 @@ from pyasn1.type import univ, char, namedtype, namedval, tag, constraint
 from pyasn1_modules import rfc3280
 from pyasn1_modules import rfc3852
 
-MAX = 64
+MAX = float('inf')
 
 
 def _buildOid(*components):

--- a/pyasn1_modules/rfc5280.py
+++ b/pyasn1_modules/rfc5280.py
@@ -20,8 +20,7 @@ from pyasn1.type import tag
 from pyasn1.type import constraint
 from pyasn1.type import useful
 
-MAX = 64
-
+MAX = float('inf')
 
 def _buildOid(*components):
     output = []

--- a/pyasn1_modules/rfc5652.py
+++ b/pyasn1_modules/rfc5652.py
@@ -21,7 +21,7 @@ from pyasn1.type import useful
 from pyasn1_modules import rfc3281
 from pyasn1_modules import rfc5280
 
-MAX = 64
+MAX = float('inf')
 
 
 def _buildOid(*components):

--- a/pyasn1_modules/rfc6402.py
+++ b/pyasn1_modules/rfc6402.py
@@ -17,7 +17,7 @@ from pyasn1_modules import rfc4211
 from pyasn1_modules import rfc5280
 from pyasn1_modules import rfc5652
 
-MAX = 64
+MAX = float('inf')
 
 
 def _buildOid(*components):


### PR DESCRIPTION
Handling of MAX in RFC should be translated to infinity as
stated in pyasn1 documentation, see
http://pyasn1.sourceforge.net/docs/tutorial.html#integer-type