### PR TITLE
Add missing MAX.

### DIFF
--- a/pyasn1_modules/rfc2437.py
+++ b/pyasn1_modules/rfc2437.py
@@ -26,6 +26,8 @@ id_mgf1 = univ.ObjectIdentifier('1.2.840.113549.1.1.8')
 id_pSpecified = univ.ObjectIdentifier('1.2.840.113549.1.1.9')
 id_sha1 = univ.ObjectIdentifier('1.3.14.3.2.26')
 
+MAX = float('inf')
+
 
 class Version(univ.Integer):
     pass


### PR DESCRIPTION
Added missing MAX to rfc2437.py, it was incorrectly removed with #3.