### PR TITLE
Added module for rfc2986 (Certification Signing Requests)

### DIFF
--- a/pyasn1_modules/rfc2986.py
+++ b/pyasn1_modules/rfc2986.py
@@ -2,7 +2,7 @@
 #
 # This file is part of pyasn1-modules software.
 #
-# Created by Stanisław Pitucha with asn1ate tool.
+# Created by Joel Johnson with asn1ate tool.
 # Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
 # License: http://pyasn1.sf.net/license.html
 #

--- a/pyasn1_modules/rfc2986.py
+++ b/pyasn1_modules/rfc2986.py
@@ -1,0 +1,124 @@
+# coding: utf-8
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Stanisław Pitucha with asn1ate tool.
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://pyasn1.sf.net/license.html
+#
+# PKCS #10: Certification Request Syntax Specification
+#
+# ASN.1 source from:
+# http://www.ietf.org/rfc/rfc2986.txt
+#
+from pyasn1.type import univ
+from pyasn1.type import char
+from pyasn1.type import namedtype
+from pyasn1.type import namedval
+from pyasn1.type import opentype
+from pyasn1.type import tag
+from pyasn1.type import constraint
+from pyasn1.type import useful
+
+MAX = float('inf')
+
+
+class AttributeType(univ.ObjectIdentifier):
+    pass
+
+
+class AttributeValue(univ.Any):
+    pass
+
+
+certificateAttributesMap = {}
+
+
+class AttributeTypeAndValue(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('type', AttributeType()),
+        namedtype.NamedType(
+            'value', AttributeValue(),
+            openType=opentype.OpenType('type', certificateAttributesMap)
+        )
+    )
+
+
+class Attribute(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('type', AttributeType()),
+        namedtype.NamedType('values',
+                            univ.SetOf(componentType=AttributeValue()),
+                            openType=opentype.OpenType('type', certificateAttributesMap))
+    )
+
+
+class Attributes(univ.SetOf):
+    pass
+
+
+Attributes.componentType = Attribute()
+
+
+class RelativeDistinguishedName(univ.SetOf):
+    pass
+
+
+RelativeDistinguishedName.componentType = AttributeTypeAndValue()
+RelativeDistinguishedName.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+
+
+class RDNSequence(univ.SequenceOf):
+    pass
+
+
+RDNSequence.componentType = RelativeDistinguishedName()
+
+
+class Name(univ.Choice):
+    pass
+
+
+Name.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('rdnSequence', RDNSequence())
+)
+
+
+class AlgorithmIdentifier(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('algorithm', univ.ObjectIdentifier()),
+        namedtype.OptionalNamedType('parameters', univ.Any())
+    )
+
+
+class SubjectPublicKeyInfo(univ.Sequence):
+    pass
+
+
+SubjectPublicKeyInfo.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('algorithm', AlgorithmIdentifier()),
+    namedtype.NamedType('subjectPublicKey', univ.BitString())
+)
+
+
+class CertificationRequestInfo(univ.Sequence):
+    pass
+
+
+CertificationRequestInfo.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('version', univ.Integer()),
+    namedtype.NamedType('subject', Name()),
+    namedtype.NamedType('subjectPKInfo', SubjectPublicKeyInfo()),
+    namedtype.NamedType('attributes', Attributes().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
+)
+
+
+class CertificationRequest(univ.Sequence):
+    pass
+
+
+CertificationRequest.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('certificationRequestInfo', CertificationRequestInfo()),
+    namedtype.NamedType('signatureAlgorithm', AlgorithmIdentifier()),
+    namedtype.NamedType('signature', univ.BitString())
+)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -17,6 +17,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc2459.suite',
      'tests.test_rfc2511.suite',
      'tests.test_rfc2560.suite',
+     'tests.test_rfc2986.suite',
      'tests.test_rfc4210.suite',
      'tests.test_rfc5208.suite',
      'tests.test_rfc5280.suite',

--- a/tests/test_rfc2986.py
+++ b/tests/test_rfc2986.py
@@ -1,0 +1,58 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Copyright (c) 2005-2017, Ilya Etingof <etingof@gmail.com>
+# License: http://pyasn1.sf.net/license.html
+#
+import sys
+
+from pyasn1.codec.der import decoder as der_decoder
+from pyasn1.codec.der import encoder as der_encoder
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc2986
+
+try:
+    import unittest2 as unittest
+
+except ImportError:
+    import unittest
+
+
+class CertificationRequestTestCase(unittest.TestCase):
+    pem_text = """\
+MIICxjCCAa4CAQAwgYAxCzAJBgNVBAYTAlVTMR0wGwYDVQQDDBRmY3UuZmFrZS5h
+ZGRyZXNzLm9yZzEXMBUGA1UEBwwOUGxlYXNhbnQgR3JvdmUxHDAaBgNVBAoME0Zh
+a2UgQ29tcGFueSBVbml0ZWQxDTALBgNVBAgMBFV0YWgxDDAKBgNVBAsMA0VuZzCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALvnYesymhLKSm9Llix53BUA
+h99xMDBUYk0OB1VIdNQyjmFabHinM+lYUzVzrfcm1xtYB5QYKbsYuwZ4r5WI7qho
+CRJy6JwXqKpOe72ScCogxlGDr2QtKjtvyWrRwXBHX1/OqVSZ3hdz3njhKpmq6HgK
+87vH26RCSmK8FqCgn+qePfpspA7GzBvYwXhXluQtG7r4yBMKNRTQlPst8Vcy+iK+
+pI8hmQVrzGi8Hgbpr2L9EjPUOlAQEb8hxeKc7s5VhjN/RHMLVMX8YczZYt7mcDKr
+3PMwOVmXL1DMCtnS50MA2AxcPWcbQBeGyMroP+DLhAt6y1/IT0H5sQruNQw4euMC
+AwEAAaAAMA0GCSqGSIb3DQEBCwUAA4IBAQBQXYQPfH5Wy4o0ZFbKQOO1e3dHV8rl
+e8m9Z6qLgJO8rtW+OI+4FavJ6zjUvNVzd9JJxgwQ/1xprwrXh36nPcSyNLpGs7JT
+6u7TGQ38QQAOmziLXzauMWGBeLuzWGmOKA1cs5HFGLSmbxF3+0IWpz4GlD86pU1+
+WYyWgWHHAMA+kFYwBUR6CvPkmhshnZ8vrQavoOlcidCJ8o6IGA7N/Z0/NrgIDcoz
+YaruhoMrmRKHKNpfamhT0gvqEPBec+UB3uLElESIqaeqYc6eMtUQP3lqyghF6I0M
+fi6h7i9VVAZpslaKFfkNg12gLbbsCB1q36l5VXjHY/qe0FIUa9ogRrOi
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc2986.CertificationRequest()
+
+    def testDerCodec(self):
+
+        substrate = pem.readBase64fromText(self.pem_text)
+
+        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encoder.encode(asn1Object) == substrate
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
I needed to use the pyasn1-module code to create certificates. During the course of working with the library, I developed this additional module for parsing CSRs. I hope that others might find it helpful too.