### PR TITLE
CI: Remove 'sudo' configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,31 +4,24 @@ matrix:
   include:
   - os: linux
     dist: xenial
-    sudo: false
     python: '2.6'
   - os: linux
     dist: xenial
-    sudo: false
     python: '2.7'
   - os: linux
     dist: xenial
-    sudo: false
     python: '3.2'
   - os: linux
     dist: xenial
-    sudo: false
     python: '3.3'
   - os: linux
     dist: xenial
-    sudo: false
     python: '3.4'
   - os: linux
     dist: xenial
-    sudo: false
     python: '3.5'
   - os: linux
     dist: xenial
-    sudo: false
     python: '3.6'
   - os: linux
     dist: xenial
@@ -36,15 +29,12 @@ matrix:
     python: '3.7'
   - os: linux
     dist: xenial
-    sudo: false
     python: 'nightly'
   - os: linux
     dist: xenial
-    sudo: false
     python: 'pypy'
   - os: linux
     dist: xenial
-    sudo: false
     python: 'pypy3'
 install:
   - pip install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
     python: '3.6'
   - os: linux
     dist: xenial
-    sudo: true
     python: '3.7'
   - os: linux
     dist: xenial


### PR DESCRIPTION
Soon Travis CI will be running builds on the same VM-based platform, regardless of the `sudo:` config.

They recommend all projects remove the `sudo: false` config. And `sudo: true` can be removed as well.

For more info: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration