### PR TITLE
Add support for RFC 5480

### DIFF
--- a/pyasn1_modules/rfc5480.py
+++ b/pyasn1_modules/rfc5480.py
@@ -1,0 +1,166 @@
+# This file is being contributed to pyasn1-modules software.
+#
+# Created by Russ Housley with assistance from asn1ate v.0.6.0.
+#
+# Copyright (c) 2019, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Elliptic Curve Cryptography Subject Public Key Information
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc5480.txt
+
+
+# What can be imported from rfc4055.py ?
+
+from pyasn1.type import namedtype
+from pyasn1.type import univ
+
+from pyasn1_modules import rfc3279
+
+
+# These structures are the same as RFC 3279.
+
+DHPublicKey = rfc3279.DHPublicKey
+
+DSAPublicKey = rfc3279.DSAPublicKey
+
+ValidationParms = rfc3279.ValidationParms
+
+DomainParameters = rfc3279.DomainParameters
+
+ECDSA_Sig_Value = rfc3279.ECDSA_Sig_Value
+
+ECPoint = rfc3279.ECPoint
+
+KEA_Parms_Id = rfc3279.KEA_Parms_Id
+
+RSAPublicKey = rfc3279.RSAPublicKey
+
+
+# RFC 5480 changed the names of these structures from RFC 3279.
+
+DSS_Parms = rfc3279.Dss_Parms
+
+DSA_Sig_Value = rfc3279.Dss_Sig_Value
+
+
+# RFC 3279 defines a more complex alternative for ECParameters.
+# RFC 5480 narrows the definition to a single CHOICE: namedCurve.
+
+class ECParameters(univ.Choice):
+    pass
+
+ECParameters.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('namedCurve', univ.ObjectIdentifier())
+)
+
+
+# OIDs for Message Digest Algorithms
+
+id_md2 = univ.ObjectIdentifier('1.2.840.113549.2.2')
+
+id_md5 = univ.ObjectIdentifier('1.2.840.113549.2.5')
+
+id_sha1 = univ.ObjectIdentifier('1.3.14.3.2.26')
+
+id_sha224 = univ.ObjectIdentifier('2.16.840.1.101.3.4.2.4')
+
+id_sha256 = univ.ObjectIdentifier('2.16.840.1.101.3.4.2.1')
+
+id_sha384 = univ.ObjectIdentifier('2.16.840.1.101.3.4.2.2')
+
+id_sha512 = univ.ObjectIdentifier('2.16.840.1.101.3.4.2.3')
+
+
+# OID for RSA PK Algorithm and Key
+
+rsaEncryption = univ.ObjectIdentifier('1.2.840.113549.1.1.1')
+
+
+# OID for DSA PK Algorithm, Key, and Parameters
+
+id_dsa = univ.ObjectIdentifier('1.2.840.10040.4.1')
+
+
+# OID for Diffie-Hellman PK Algorithm, Key, and Parameters
+
+dhpublicnumber = univ.ObjectIdentifier('1.2.840.10046.2.1')
+
+# OID for KEA PK Algorithm and Parameters
+
+id_keyExchangeAlgorithm = univ.ObjectIdentifier('2.16.840.1.101.2.1.1.22')
+
+
+# OIDs for Elliptic Curve Algorithm ID, Key, and Parameters
+# Note that ECDSA keys always use this OID
+
+id_ecPublicKey = univ.ObjectIdentifier('1.2.840.10045.2.1')
+
+id_ecDH = univ.ObjectIdentifier('1.3.132.1.12')
+
+id_ecMQV = univ.ObjectIdentifier('1.3.132.1.13')
+
+
+# OIDs for RSA Signature Algorithms
+
+md2WithRSAEncryption = univ.ObjectIdentifier('1.2.840.113549.1.1.2')
+
+md5WithRSAEncryption = univ.ObjectIdentifier('1.2.840.113549.1.1.4')
+
+sha1WithRSAEncryption = univ.ObjectIdentifier('1.2.840.113549.1.1.5')
+
+
+# OIDs for DSA Signature Algorithms
+
+id_dsa_with_sha1 = univ.ObjectIdentifier('1.2.840.10040.4.3')
+
+id_dsa_with_sha224 = univ.ObjectIdentifier('2.16.840.1.101.3.4.3.1')
+
+id_dsa_with_sha256 = univ.ObjectIdentifier('2.16.840.1.101.3.4.3.2')
+
+
+# OIDs for ECDSA Signature Algorithms
+
+ecdsa_with_SHA1 = univ.ObjectIdentifier('1.2.840.10045.4.1')
+
+ecdsa_with_SHA224 = univ.ObjectIdentifier('1.2.840.10045.4.3.1')
+
+ecdsa_with_SHA256 = univ.ObjectIdentifier('1.2.840.10045.4.3.2')
+
+ecdsa_with_SHA384 = univ.ObjectIdentifier('1.2.840.10045.4.3.3')
+
+ecdsa_with_SHA512 = univ.ObjectIdentifier('1.2.840.10045.4.3.4')
+
+
+# OIDs for Named Elliptic Curves
+
+secp192r1 = univ.ObjectIdentifier('1.2.840.10045.3.1.1')
+
+sect163k1 = univ.ObjectIdentifier('1.3.132.0.1')
+
+sect163r2 = univ.ObjectIdentifier('1.3.132.0.15')
+
+secp224r1 = univ.ObjectIdentifier('1.3.132.0.33')
+
+sect233k1 = univ.ObjectIdentifier('1.3.132.0.26')
+
+sect233r1 = univ.ObjectIdentifier('1.3.132.0.27')
+
+secp256r1 = univ.ObjectIdentifier('1.2.840.10045.3.1.7')
+
+sect283k1 = univ.ObjectIdentifier('1.3.132.0.16')
+
+sect283r1 = univ.ObjectIdentifier('1.3.132.0.17')
+
+secp384r1 = univ.ObjectIdentifier('1.3.132.0.34')
+
+sect409k1 = univ.ObjectIdentifier('1.3.132.0.36')
+
+sect409r1 = univ.ObjectIdentifier('1.3.132.0.37')
+
+secp521r1 = univ.ObjectIdentifier('1.3.132.0.35')
+
+sect571k1 = univ.ObjectIdentifier('1.3.132.0.38')
+
+sect571r1 = univ.ObjectIdentifier('1.3.132.0.39')

--- a/tests/test_rfc5480.py
+++ b/tests/test_rfc5480.py
@@ -1,0 +1,68 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2019, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+
+import sys
+
+from pyasn1.codec.der import decoder as der_decoder
+from pyasn1.codec.der import encoder as der_encoder
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc5480
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+class ECCertTestCase(unittest.TestCase):
+    digicert_ec_cert_pem_text = """\
+MIIDrDCCApSgAwIBAgIQCssoukZe5TkIdnRw883GEjANBgkqhkiG9w0BAQwFADBh
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD
+QTAeFw0xMzAzMDgxMjAwMDBaFw0yMzAzMDgxMjAwMDBaMEwxCzAJBgNVBAYTAlVT
+MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxJjAkBgNVBAMTHURpZ2lDZXJ0IEVDQyBT
+ZWN1cmUgU2VydmVyIENBMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4ghC6nfYJN6g
+LGSkE85AnCNyqQIKDjc/ITa4jVMU9tWRlUvzlgKNcR7E2Munn17voOZ/WpIRllNv
+68DLP679Wz9HJOeaBy6Wvqgvu1cYr3GkvXg6HuhbPGtkESvMNCuMo4IBITCCAR0w
+EgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAYYwNAYIKwYBBQUHAQEE
+KDAmMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wQgYDVR0f
+BDswOTA3oDWgM4YxaHR0cDovL2NybDMuZGlnaWNlcnQuY29tL0RpZ2lDZXJ0R2xv
+YmFsUm9vdENBLmNybDA9BgNVHSAENjA0MDIGBFUdIAAwKjAoBggrBgEFBQcCARYc
+aHR0cHM6Ly93d3cuZGlnaWNlcnQuY29tL0NQUzAdBgNVHQ4EFgQUo53mH/naOU/A
+buiRy5Wl2jHiCp8wHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUwDQYJ
+KoZIhvcNAQEMBQADggEBAMeKoENL7HTJxavVHzA1Nm6YVntIrAVjrnuaVyRXzG/6
+3qttnMe2uuzO58pzZNvfBDcKAEmzP58mrZGMIOgfiA4q+2Y3yDDo0sIkp0VILeoB
+UEoxlBPfjV/aKrtJPGHzecicZpIalir0ezZYoyxBEHQa0+1IttK7igZFcTMQMHp6
+mCHdJLnsnLWSB62DxsRq+HfmNb4TDydkskO/g+l3VtsIh5RHFPVfKK+jaEyDj2D3
+loB5hWp2Jp2VDCADjT7ueihlZGak2YPqmXTNbk19HOuNssWvFhtOyPNV6og4ETQd
+Ea8/B6hPatJ0ES8q/HO3X8IVQwVs1n3aAr0im0/T+Xc=
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5280.Certificate()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.digicert_ec_cert_pem_text)
+        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encoder.encode(asn1Object) == substrate
+        assert substrate == der_encoder.encode(asn1Object)
+
+        algid = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
+        assert algid['algorithm'] == rfc5480.id_ecPublicKey
+        param, rest = der_decoder.decode(algid['parameters'], asn1Spec=rfc5480.ECParameters())
+        assert param.prettyPrint()
+        assert param['namedCurve'] == rfc5480.secp384r1
+        
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Add module and test to support RFC 5480, which has one very significant change to structures that were previously specified in RFC 3279.