### PR TITLE
Make SIZE OF constraint operational

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,13 @@ Revision 0.2.6, released XX-07-2019
   RFC 3779, RFC 4055, RFC 4073, RFC 4108, RFC 5035, RFC 5083, RFC 5480,
   RFC 5940, RFC 5958, RFC 6010, RFC 6019, RFC 6402, RFC 7191, RFC 8226,
   and RFC 8520
+- Changed `ValueSizeConstraint` erroneously applied to `SequenceOf`
+  and `SetOf` objects via `subtypeConstraint` attribute to be applied
+  via `sizeSpec` attribute. Although `sizeSpec` takes the same constraint
+  objects as `subtypeConstraint`, the former is only verified on
+  de/serialization i.e. when the [constructed] object at hand is fully
+  populated, while the latter is applied to [scalar] types at the moment
+  of instantiation.
 
 Revision 0.2.5, released 24-04-2019
 -----------------------------------

--- a/pyasn1_modules/rfc1905.py
+++ b/pyasn1_modules/rfc1905.py
@@ -42,7 +42,7 @@ class VarBind(univ.Sequence):
 
 class VarBindList(univ.SequenceOf):
     componentType = VarBind()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(
         0, max_bindings
     )
 

--- a/pyasn1_modules/rfc2315.py
+++ b/pyasn1_modules/rfc2315.py
@@ -269,13 +269,13 @@ class DigestInfo(univ.Sequence):
 class SignedData(univ.Sequence):
     componentType = namedtype.NamedTypes(
         namedtype.NamedType('version', Version()),
-        namedtype.NamedType('digestAlgorithms', DigestAlgorithmIdentifiers()),
+        namedtype.OptionalNamedType('digestAlgorithms', DigestAlgorithmIdentifiers()),
         namedtype.NamedType('contentInfo', ContentInfo()),
         namedtype.OptionalNamedType('certificates', ExtendedCertificatesAndCertificates().subtype(
             implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
         namedtype.OptionalNamedType('crls', CertificateRevocationLists().subtype(
             implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1))),
-        namedtype.NamedType('signerInfos', SignerInfos())
+        namedtype.OptionalNamedType('signerInfos', SignerInfos())
     )
 
 

--- a/pyasn1_modules/rfc2459.py
+++ b/pyasn1_modules/rfc2459.py
@@ -354,7 +354,7 @@ class TeletexDomainDefinedAttribute(univ.Sequence):
 
 class TeletexDomainDefinedAttributes(univ.SequenceOf):
     componentType = TeletexDomainDefinedAttribute()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
 
 
 terminal_type = univ.Integer(23)
@@ -545,7 +545,7 @@ teletex_organizational_unit_names = univ.Integer(5)
 
 class TeletexOrganizationalUnitNames(univ.SequenceOf):
     componentType = TeletexOrganizationalUnitName()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, ub_organizational_units)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, ub_organizational_units)
 
 
 teletex_personal_name = univ.Integer(4)
@@ -601,7 +601,7 @@ class ExtensionAttribute(univ.Sequence):
 
 class ExtensionAttributes(univ.SetOf):
     componentType = ExtensionAttribute()
-    subtypeSpec = univ.SetOf.subtypeSpec + constraint.ValueSizeConstraint(1, ub_extension_attributes)
+    sizeSpec = univ.SetOf.sizeSpec + constraint.ValueSizeConstraint(1, ub_extension_attributes)
 
 
 class BuiltInDomainDefinedAttribute(univ.Sequence):
@@ -615,16 +615,16 @@ class BuiltInDomainDefinedAttribute(univ.Sequence):
 
 class BuiltInDomainDefinedAttributes(univ.SequenceOf):
     componentType = BuiltInDomainDefinedAttribute()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
 
 
 class OrganizationalUnitName(char.PrintableString):
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, ub_organizational_unit_name_length)
+    subtypeSpec = char.PrintableString.subtypeSpec + constraint.ValueSizeConstraint(1, ub_organizational_unit_name_length)
 
 
 class OrganizationalUnitNames(univ.SequenceOf):
     componentType = OrganizationalUnitName()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, ub_organizational_units)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, ub_organizational_units)
 
 
 class PersonalName(univ.Set):
@@ -771,7 +771,7 @@ id_ce_cRLNumber = univ.ObjectIdentifier('2.5.29.20')
 
 
 class CRLNumber(univ.Integer):
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(0, MAX)
+    subtypeSpec = univ.Integer.subtypeSpec + constraint.ValueSizeConstraint(0, MAX)
 
 
 class BaseCRLNumber(CRLNumber):
@@ -796,7 +796,7 @@ class KeyPurposeId(univ.ObjectIdentifier):
 
 class ExtKeyUsageSyntax(univ.SequenceOf):
     componentType = KeyPurposeId()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class ReasonFlags(univ.BitString):
@@ -925,7 +925,7 @@ class PolicyInformation(univ.Sequence):
 
 class CertificatePolicies(univ.SequenceOf):
     componentType = PolicyInformation()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 id_ce_policyMappings = univ.ObjectIdentifier('2.5.29.33')
@@ -940,7 +940,7 @@ class PolicyMapping(univ.Sequence):
 
 class PolicyMappings(univ.SequenceOf):
     componentType = PolicyMapping()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 id_ce_privateKeyUsagePeriod = univ.ObjectIdentifier('2.5.29.16')
@@ -1024,7 +1024,7 @@ class Attribute(univ.Sequence):
 
 class SubjectDirectoryAttributes(univ.SequenceOf):
     componentType = Attribute()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class RelativeDistinguishedName(univ.SetOf):
@@ -1077,7 +1077,7 @@ class GeneralName(univ.Choice):
 
 class GeneralNames(univ.SequenceOf):
     componentType = GeneralName()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class AccessDescription(univ.Sequence):
@@ -1089,7 +1089,7 @@ class AccessDescription(univ.Sequence):
 
 class AuthorityInfoAccessSyntax(univ.SequenceOf):
     componentType = AccessDescription()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class AuthorityKeyIdentifier(univ.Sequence):
@@ -1125,7 +1125,7 @@ class DistributionPoint(univ.Sequence):
 
 class CRLDistPointsSyntax(univ.SequenceOf):
     componentType = DistributionPoint()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class IssuingDistributionPoint(univ.Sequence):
@@ -1155,7 +1155,7 @@ class GeneralSubtree(univ.Sequence):
 
 class GeneralSubtrees(univ.SequenceOf):
     componentType = GeneralSubtree()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class NameConstraints(univ.Sequence):

--- a/pyasn1_modules/rfc2511.py
+++ b/pyasn1_modules/rfc2511.py
@@ -109,7 +109,7 @@ class PKIPublicationInfo(univ.Sequence):
         namedtype.NamedType('action',
                             univ.Integer(namedValues=namedval.NamedValues(('dontPublish', 0), ('pleasePublish', 1)))),
         namedtype.OptionalNamedType('pubInfos', univ.SequenceOf(componentType=SinglePubInfo()).subtype(
-            subtypeSpec=constraint.ValueSizeConstraint(1, MAX)))
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX)))
     )
 
 
@@ -195,7 +195,7 @@ class ProofOfPossession(univ.Choice):
 
 class Controls(univ.SequenceOf):
     componentType = AttributeTypeAndValue()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class OptionalValidity(univ.Sequence):
@@ -249,10 +249,10 @@ class CertReqMsg(univ.Sequence):
         namedtype.NamedType('certReq', CertRequest()),
         namedtype.OptionalNamedType('pop', ProofOfPossession()),
         namedtype.OptionalNamedType('regInfo', univ.SequenceOf(componentType=AttributeTypeAndValue()).subtype(
-            subtypeSpec=constraint.ValueSizeConstraint(1, MAX)))
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX)))
     )
 
 
 class CertReqMessages(univ.SequenceOf):
     componentType = CertReqMsg()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)

--- a/pyasn1_modules/rfc2634.py
+++ b/pyasn1_modules/rfc2634.py
@@ -101,11 +101,11 @@ MLReceiptPolicy.componentType = namedtype.NamedTypes(
         tag.tagClassContext, tag.tagFormatSimple, 0))),
     namedtype.NamedType('insteadOf', univ.SequenceOf(
         componentType=GeneralNames()).subtype(
-        subtypeSpec=constraint.ValueSizeConstraint(1, MAX)).subtype(
+        sizeSpec=constraint.ValueSizeConstraint(1, MAX)).subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
     namedtype.NamedType('inAdditionTo', univ.SequenceOf(
         componentType=GeneralNames()).subtype(
-        subtypeSpec=constraint.ValueSizeConstraint(1, MAX)).subtype(
+        sizeSpec=constraint.ValueSizeConstraint(1, MAX)).subtype(
         implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)))
 )
 
@@ -123,7 +123,7 @@ class MLExpansionHistory(univ.SequenceOf):
     pass
 
 MLExpansionHistory.componentType = MLData()
-MLExpansionHistory.subtypeSpec=constraint.ValueSizeConstraint(1, ub_ml_expansion_history)
+MLExpansionHistory.sizeSpec = constraint.ValueSizeConstraint(1, ub_ml_expansion_history)
 
 
 # ESS Security Label Attribute
@@ -182,7 +182,7 @@ class SecurityCategories(univ.SetOf):
     pass
 
 SecurityCategories.componentType = SecurityCategory()
-SecurityCategories.subtypeSpec=constraint.ValueSizeConstraint(1, ub_security_categories)
+SecurityCategories.sizeSpec = constraint.ValueSizeConstraint(1, ub_security_categories)
 
 
 class ESSSecurityLabel(univ.Set):
@@ -282,7 +282,7 @@ class ReceiptRequest(univ.Sequence):
 ReceiptRequest.componentType = namedtype.NamedTypes(
     namedtype.NamedType('signedContentIdentifier', ContentIdentifier()),
     namedtype.NamedType('receiptsFrom', ReceiptsFrom()),
-    namedtype.NamedType('receiptsTo', univ.SequenceOf(componentType=GeneralNames()).subtype(subtypeSpec=constraint.ValueSizeConstraint(1, ub_receiptsTo)))
+    namedtype.NamedType('receiptsTo', univ.SequenceOf(componentType=GeneralNames()).subtype(sizeSpec=constraint.ValueSizeConstraint(1, ub_receiptsTo)))
 )
 
 # Receipt Content Type

--- a/pyasn1_modules/rfc2986.py
+++ b/pyasn1_modules/rfc2986.py
@@ -45,11 +45,13 @@ SubjectPublicKeyInfo = rfc5280.SubjectPublicKeyInfo
 class Attributes(univ.SetOf):
     pass
 
+
 Attributes.componentType = Attribute()
 
 
 class CertificationRequestInfo(univ.Sequence):
     pass
+
 
 CertificationRequestInfo.componentType = namedtype.NamedTypes(
     namedtype.NamedType('version', univ.Integer()),
@@ -64,6 +66,7 @@ CertificationRequestInfo.componentType = namedtype.NamedTypes(
 
 class CertificationRequest(univ.Sequence):
     pass
+
 
 CertificationRequest.componentType = namedtype.NamedTypes(
     namedtype.NamedType('certificationRequestInfo', CertificationRequestInfo()),

--- a/pyasn1_modules/rfc3280.py
+++ b/pyasn1_modules/rfc3280.py
@@ -53,7 +53,7 @@ class OrganizationalUnitNames(univ.SequenceOf):
 
 
 OrganizationalUnitNames.componentType = OrganizationalUnitName()
-OrganizationalUnitNames.subtypeSpec = constraint.ValueSizeConstraint(1, ub_organizational_units)
+OrganizationalUnitNames.sizeSpec = constraint.ValueSizeConstraint(1, ub_organizational_units)
 
 
 class AttributeType(univ.ObjectIdentifier):
@@ -152,7 +152,7 @@ class Extensions(univ.SequenceOf):
 
 
 Extensions.componentType = Extension()
-Extensions.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+Extensions.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class CertificateSerialNumber(univ.Integer):
@@ -219,7 +219,7 @@ class RelativeDistinguishedName(univ.SetOf):
 
 
 RelativeDistinguishedName.componentType = AttributeTypeAndValue()
-RelativeDistinguishedName.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+RelativeDistinguishedName.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class RDNSequence(univ.SequenceOf):
@@ -519,7 +519,7 @@ class BuiltInDomainDefinedAttributes(univ.SequenceOf):
 
 
 BuiltInDomainDefinedAttributes.componentType = BuiltInDomainDefinedAttribute()
-BuiltInDomainDefinedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
+BuiltInDomainDefinedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
 
 ub_extension_attributes = univ.Integer(256)
 
@@ -542,7 +542,7 @@ class ExtensionAttributes(univ.SetOf):
 
 
 ExtensionAttributes.componentType = ExtensionAttribute()
-ExtensionAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, ub_extension_attributes)
+ExtensionAttributes.sizeSpec = constraint.ValueSizeConstraint(1, ub_extension_attributes)
 
 
 class ORAddress(univ.Sequence):
@@ -706,7 +706,7 @@ class TeletexDomainDefinedAttributes(univ.SequenceOf):
 
 
 TeletexDomainDefinedAttributes.componentType = TeletexDomainDefinedAttribute()
-TeletexDomainDefinedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
+TeletexDomainDefinedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
 
 
 class TBSCertList(univ.Sequence):
@@ -905,7 +905,7 @@ class TeletexOrganizationalUnitNames(univ.SequenceOf):
 
 
 TeletexOrganizationalUnitNames.componentType = TeletexOrganizationalUnitName()
-TeletexOrganizationalUnitNames.subtypeSpec = constraint.ValueSizeConstraint(1, ub_organizational_units)
+TeletexOrganizationalUnitNames.sizeSpec = constraint.ValueSizeConstraint(1, ub_organizational_units)
 
 physical_delivery_office_name = univ.Integer(10)
 
@@ -1077,7 +1077,7 @@ class GeneralNames(univ.SequenceOf):
 
 
 GeneralNames.componentType = GeneralName()
-GeneralNames.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+GeneralNames.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class IssuerAltName(GeneralNames):
@@ -1100,7 +1100,7 @@ PolicyMappings.componentType = univ.Sequence(componentType=namedtype.NamedTypes(
     namedtype.NamedType('subjectDomainPolicy', CertPolicyId())
 ))
 
-PolicyMappings.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+PolicyMappings.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class PolicyQualifierId(univ.ObjectIdentifier):
@@ -1119,7 +1119,7 @@ class SubjectDirectoryAttributes(univ.SequenceOf):
 
 
 SubjectDirectoryAttributes.componentType = Attribute()
-SubjectDirectoryAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+SubjectDirectoryAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 anyPolicy = _OID(id_ce_certificatePolicies, 0)
 
@@ -1198,7 +1198,7 @@ class CertificatePolicies(univ.SequenceOf):
 
 
 CertificatePolicies.componentType = PolicyInformation()
-CertificatePolicies.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+CertificatePolicies.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 id_ce_basicConstraints = _OID(id_ce, 19)
 
@@ -1216,7 +1216,7 @@ class ExtKeyUsageSyntax(univ.SequenceOf):
 
 
 ExtKeyUsageSyntax.componentType = KeyPurposeId()
-ExtKeyUsageSyntax.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+ExtKeyUsageSyntax.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class SubjectAltName(GeneralNames):
@@ -1287,7 +1287,7 @@ class CRLDistributionPoints(univ.SequenceOf):
 
 
 CRLDistributionPoints.componentType = DistributionPoint()
-CRLDistributionPoints.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+CRLDistributionPoints.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class FreshestCRL(CRLDistributionPoints):
@@ -1340,7 +1340,7 @@ class GeneralSubtrees(univ.SequenceOf):
 
 
 GeneralSubtrees.componentType = GeneralSubtree()
-GeneralSubtrees.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+GeneralSubtrees.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class NameConstraints(univ.Sequence):
@@ -1389,7 +1389,7 @@ class AuthorityInfoAccessSyntax(univ.SequenceOf):
 
 
 AuthorityInfoAccessSyntax.componentType = AccessDescription()
-AuthorityInfoAccessSyntax.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+AuthorityInfoAccessSyntax.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 id_ce_issuingDistributionPoint = _OID(id_ce, 28)
 
@@ -1458,7 +1458,7 @@ class SubjectInfoAccessSyntax(univ.SequenceOf):
 
 
 SubjectInfoAccessSyntax.componentType = AccessDescription()
-SubjectInfoAccessSyntax.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+SubjectInfoAccessSyntax.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class KeyUsage(univ.BitString):

--- a/pyasn1_modules/rfc3447.py
+++ b/pyasn1_modules/rfc3447.py
@@ -27,7 +27,7 @@ class OtherPrimeInfo(univ.Sequence):
 
 class OtherPrimeInfos(univ.SequenceOf):
     componentType = OtherPrimeInfo()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class RSAPrivateKey(univ.Sequence):

--- a/pyasn1_modules/rfc3709.py
+++ b/pyasn1_modules/rfc3709.py
@@ -41,10 +41,10 @@ LogotypeDetails.componentType = namedtype.NamedTypes(
     namedtype.NamedType('mediaType', char.IA5String()),
     namedtype.NamedType('logotypeHash', univ.SequenceOf(
         componentType=HashAlgAndValue()).subtype(
-            subtypeSpec=constraint.ValueSizeConstraint(1, MAX))),
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX))),
     namedtype.NamedType('logotypeURI', univ.SequenceOf(
         componentType=char.IA5String()).subtype(
-            subtypeSpec=constraint.ValueSizeConstraint(1, MAX)))
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX)))
 )
 
 
@@ -137,10 +137,10 @@ class LogotypeReference(univ.Sequence):
 LogotypeReference.componentType = namedtype.NamedTypes(
     namedtype.NamedType('refStructHash', univ.SequenceOf(
         componentType=HashAlgAndValue()).subtype(
-            subtypeSpec=constraint.ValueSizeConstraint(1, MAX))),
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX))),
     namedtype.NamedType('refStructURI', univ.SequenceOf(
         componentType=char.IA5String()).subtype(
-             subtypeSpec=constraint.ValueSizeConstraint(1, MAX)))
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX)))
 )
 
 

--- a/pyasn1_modules/rfc3852.py
+++ b/pyasn1_modules/rfc3852.py
@@ -54,7 +54,7 @@ class SignedAttributes(univ.SetOf):
 
 
 SignedAttributes.componentType = Attribute()
-SignedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+SignedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class OtherRevocationInfoFormat(univ.Sequence):
@@ -309,7 +309,7 @@ class RecipientInfos(univ.SetOf):
 
 
 RecipientInfos.componentType = RecipientInfo()
-RecipientInfos.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+RecipientInfos.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class DigestAlgorithmIdentifier(rfc3280.AlgorithmIdentifier):
@@ -336,7 +336,7 @@ class UnprotectedAttributes(univ.SetOf):
 
 
 UnprotectedAttributes.componentType = Attribute()
-UnprotectedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+UnprotectedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class ContentType(univ.ObjectIdentifier):
@@ -430,7 +430,7 @@ class UnauthAttributes(univ.SetOf):
 
 
 UnauthAttributes.componentType = Attribute()
-UnauthAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+UnauthAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class ExtendedCertificateInfo(univ.Sequence):
@@ -550,7 +550,7 @@ class UnsignedAttributes(univ.SetOf):
 
 
 UnsignedAttributes.componentType = Attribute()
-UnsignedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+UnsignedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class SignatureValue(univ.OctetString):
@@ -632,7 +632,7 @@ class AuthAttributes(univ.SetOf):
 
 
 AuthAttributes.componentType = Attribute()
-AuthAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+AuthAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class AuthenticatedData(univ.Sequence):

--- a/pyasn1_modules/rfc4073.py
+++ b/pyasn1_modules/rfc4073.py
@@ -30,7 +30,7 @@ class ContentCollection(univ.SequenceOf):
     pass
 
 ContentCollection.componentType = rfc5652.ContentInfo()
-ContentCollection.subtypeSpec=constraint.ValueSizeConstraint(1, MAX)
+ContentCollection.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 # Content With Attributes Content Type and Object Identifier
@@ -44,7 +44,7 @@ ContentWithAttributes.componentType = namedtype.NamedTypes(
     namedtype.NamedType('content', rfc5652.ContentInfo()),
     namedtype.NamedType('attrs', univ.SequenceOf(
         componentType=rfc5652.Attribute()).subtype(
-            subtypeSpec=constraint.ValueSizeConstraint(1, MAX)))
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX)))
 )
 
 

--- a/pyasn1_modules/rfc4210.py
+++ b/pyasn1_modules/rfc4210.py
@@ -44,7 +44,7 @@ class PKIFreeText(univ.SequenceOf):
     PKIFreeText ::= SEQUENCE SIZE (1..MAX) OF UTF8String
     """
     componentType = char.UTF8String()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 class PollRepContent(univ.SequenceOf):
@@ -354,16 +354,17 @@ class RevRepContent(univ.Sequence):
                                              OPTIONAL
     """
     componentType = namedtype.NamedTypes(
-        namedtype.NamedType('status', PKIStatusInfo()),
+        namedtype.NamedType('status', PKIStatusInfo(
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX))),
         namedtype.OptionalNamedType(
             'revCerts', univ.SequenceOf(componentType=rfc2511.CertId()).subtype(
-                subtypeSpec=constraint.ValueSizeConstraint(1, MAX),
+                sizeSpec=constraint.ValueSizeConstraint(1, MAX),
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0)
             )
         ),
         namedtype.OptionalNamedType(
             'crls', univ.SequenceOf(componentType=rfc2459.CertificateList()).subtype(
-                subtypeSpec=constraint.ValueSizeConstraint(1, MAX),
+                sizeSpec=constraint.ValueSizeConstraint(1, MAX),
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)
             )
         )
@@ -391,12 +392,12 @@ class KeyRecRepContent(univ.Sequence):
         namedtype.OptionalNamedType(
             'caCerts', univ.SequenceOf(componentType=CMPCertificate()).subtype(
                 explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1),
-                subtypeSpec=constraint.ValueSizeConstraint(1, MAX)
+                sizeSpec=constraint.ValueSizeConstraint(1, MAX)
             )
         ),
         namedtype.OptionalNamedType('keyPairHist', univ.SequenceOf(componentType=CertifiedKeyPair()).subtype(
             explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 2),
-            subtypeSpec=constraint.ValueSizeConstraint(1, MAX))
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX))
         )
     )
 
@@ -430,7 +431,8 @@ class CertRepMessage(univ.Sequence):
         namedtype.OptionalNamedType(
             'caPubs', univ.SequenceOf(
                 componentType=CMPCertificate()
-            ).subtype(subtypeSpec=constraint.ValueSizeConstraint(1, MAX), explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1))
+            ).subtype(sizeSpec=constraint.ValueSizeConstraint(1, MAX),
+                      explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1))
         ),
         namedtype.NamedType('response', univ.SequenceOf(componentType=CertResponse()))
     )
@@ -737,7 +739,7 @@ class PKIHeader(univ.Sequence):
         namedtype.OptionalNamedType('generalInfo',
                                     univ.SequenceOf(
                                         componentType=InfoTypeAndValue().subtype(
-                                            subtypeSpec=constraint.ValueSizeConstraint(1, MAX),
+                                            sizeSpec=constraint.ValueSizeConstraint(1, MAX),
                                             explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 8)
                                         )
                                     )
@@ -776,7 +778,7 @@ class PKIMessage(univ.Sequence):
                                     univ.SequenceOf(
                                         componentType=CMPCertificate()
                                     ).subtype(
-                                        subtypeSpec=constraint.ValueSizeConstraint(1, MAX),
+                                        sizeSpec=constraint.ValueSizeConstraint(1, MAX),
                                         explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)
                                     )
                                     )
@@ -788,7 +790,7 @@ class PKIMessages(univ.SequenceOf):
     PKIMessages ::= SEQUENCE SIZE (1..MAX) OF PKIMessage
     """
     componentType = PKIMessage()
-    subtypeSpec = univ.SequenceOf.subtypeSpec + constraint.ValueSizeConstraint(1, MAX)
+    sizeSpec = univ.SequenceOf.sizeSpec + constraint.ValueSizeConstraint(1, MAX)
 
 
 # pyasn1 does not naturally handle recursive definitions, thus this hack:

--- a/pyasn1_modules/rfc4211.py
+++ b/pyasn1_modules/rfc4211.py
@@ -282,7 +282,7 @@ class Controls(univ.SequenceOf):
 
 
 Controls.componentType = AttributeTypeAndValue()
-Controls.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+Controls.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class CertRequest(univ.Sequence):
@@ -312,7 +312,7 @@ class CertReqMessages(univ.SequenceOf):
 
 
 CertReqMessages.componentType = CertReqMsg()
-CertReqMessages.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+CertReqMessages.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class CertReq(CertRequest):

--- a/pyasn1_modules/rfc5280.py
+++ b/pyasn1_modules/rfc5280.py
@@ -75,7 +75,7 @@ class Extensions(univ.SequenceOf):
 
 
 Extensions.componentType = Extension()
-Extensions.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+Extensions.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 physical_delivery_personal_name = univ.Integer(13)
 
@@ -206,7 +206,7 @@ class TeletexDomainDefinedAttributes(univ.SequenceOf):
 
 
 TeletexDomainDefinedAttributes.componentType = TeletexDomainDefinedAttribute()
-TeletexDomainDefinedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
+TeletexDomainDefinedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
 
 extended_network_address = univ.Integer(22)
 
@@ -285,6 +285,7 @@ class CertificateSerialNumber(univ.Integer):
 
 algorithmIdentifierMap = {}
 
+
 class AlgorithmIdentifier(univ.Sequence):
     componentType = namedtype.NamedTypes(
         namedtype.NamedType('algorithm', univ.ObjectIdentifier()),
@@ -326,7 +327,7 @@ class RelativeDistinguishedName(univ.SetOf):
 
 
 RelativeDistinguishedName.componentType = AttributeTypeAndValue()
-RelativeDistinguishedName.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+RelativeDistinguishedName.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class RDNSequence(univ.SequenceOf):
@@ -648,7 +649,7 @@ class ExtensionAttributes(univ.SetOf):
 
 
 ExtensionAttributes.componentType = ExtensionAttribute()
-ExtensionAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, ub_extension_attributes)
+ExtensionAttributes.sizeSpec = constraint.ValueSizeConstraint(1, ub_extension_attributes)
 
 ub_emailaddress_length = univ.Integer(255)
 
@@ -795,7 +796,7 @@ class BuiltInDomainDefinedAttributes(univ.SequenceOf):
 
 
 BuiltInDomainDefinedAttributes.componentType = BuiltInDomainDefinedAttribute()
-BuiltInDomainDefinedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
+BuiltInDomainDefinedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, ub_domain_defined_attributes)
 
 id_at_pseudonym = _buildOid(id_at, 65)
 
@@ -876,7 +877,7 @@ class OrganizationalUnitNames(univ.SequenceOf):
 
 
 OrganizationalUnitNames.componentType = OrganizationalUnitName()
-OrganizationalUnitNames.subtypeSpec = constraint.ValueSizeConstraint(1, ub_organizational_units)
+OrganizationalUnitNames.sizeSpec = constraint.ValueSizeConstraint(1, ub_organizational_units)
 
 
 class PrivateDomainName(univ.Choice):
@@ -1035,7 +1036,7 @@ class TeletexOrganizationalUnitNames(univ.SequenceOf):
 
 
 TeletexOrganizationalUnitNames.componentType = TeletexOrganizationalUnitName()
-TeletexOrganizationalUnitNames.subtypeSpec = constraint.ValueSizeConstraint(1, ub_organizational_units)
+TeletexOrganizationalUnitNames.sizeSpec = constraint.ValueSizeConstraint(1, ub_organizational_units)
 
 id_ce = _buildOid(2, 5, 29)
 
@@ -1158,7 +1159,7 @@ class GeneralNames(univ.SequenceOf):
 
 
 GeneralNames.componentType = GeneralName()
-GeneralNames.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+GeneralNames.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class DistributionPointName(univ.Choice):
@@ -1258,7 +1259,7 @@ class CRLDistributionPoints(univ.SequenceOf):
 
 
 CRLDistributionPoints.componentType = DistributionPoint()
-CRLDistributionPoints.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+CRLDistributionPoints.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class GeneralSubtrees(univ.SequenceOf):
@@ -1266,7 +1267,7 @@ class GeneralSubtrees(univ.SequenceOf):
 
 
 GeneralSubtrees.componentType = GeneralSubtree()
-GeneralSubtrees.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+GeneralSubtrees.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class NameConstraints(univ.Sequence):
@@ -1286,7 +1287,7 @@ class SubjectDirectoryAttributes(univ.SequenceOf):
 
 
 SubjectDirectoryAttributes.componentType = Attribute()
-SubjectDirectoryAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+SubjectDirectoryAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 id_kp_OCSPSigning = _buildOid(id_kp, 9)
 
@@ -1364,7 +1365,7 @@ class CertificatePolicies(univ.SequenceOf):
 
 
 CertificatePolicies.componentType = PolicyInformation()
-CertificatePolicies.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+CertificatePolicies.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class SubjectAltName(GeneralNames):
@@ -1402,7 +1403,7 @@ PolicyMappings.componentType = univ.Sequence(
     )
 )
 
-PolicyMappings.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+PolicyMappings.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class InhibitAnyPolicy(SkipCerts):
@@ -1466,7 +1467,7 @@ class AuthorityInfoAccessSyntax(univ.SequenceOf):
 
 
 AuthorityInfoAccessSyntax.componentType = AccessDescription()
-AuthorityInfoAccessSyntax.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+AuthorityInfoAccessSyntax.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 id_holdinstruction_none = _buildOid(holdInstruction, 1)
 
@@ -1494,7 +1495,7 @@ class ExtKeyUsageSyntax(univ.SequenceOf):
 
 
 ExtKeyUsageSyntax.componentType = KeyPurposeId()
-ExtKeyUsageSyntax.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+ExtKeyUsageSyntax.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class HoldInstructionCode(univ.ObjectIdentifier):
@@ -1513,7 +1514,7 @@ class SubjectInfoAccessSyntax(univ.SequenceOf):
 
 
 SubjectInfoAccessSyntax.componentType = AccessDescription()
-SubjectInfoAccessSyntax.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+SubjectInfoAccessSyntax.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class InvalidityDate(useful.GeneralizedTime):

--- a/pyasn1_modules/rfc5652.py
+++ b/pyasn1_modules/rfc5652.py
@@ -116,7 +116,7 @@ class SignedAttributes(univ.SetOf):
 
 
 SignedAttributes.componentType = Attribute()
-SignedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+SignedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class AttributeCertificateV2(rfc3281.AttributeCertificate):
@@ -140,7 +140,7 @@ class UnauthAttributes(univ.SetOf):
 
 
 UnauthAttributes.componentType = Attribute()
-UnauthAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+UnauthAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 id_encryptedData = _buildOid(1, 2, 840, 113549, 1, 7, 6)
 
@@ -361,7 +361,7 @@ class UnprotectedAttributes(univ.SetOf):
 
 
 UnprotectedAttributes.componentType = Attribute()
-UnprotectedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+UnprotectedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class KeyEncryptionAlgorithmIdentifier(rfc5280.AlgorithmIdentifier):
@@ -507,7 +507,7 @@ class RecipientInfos(univ.SetOf):
 
 
 RecipientInfos.componentType = RecipientInfo()
-RecipientInfos.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+RecipientInfos.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class EnvelopedData(univ.Sequence):
@@ -559,7 +559,7 @@ class UnsignedAttributes(univ.SetOf):
 
 
 UnsignedAttributes.componentType = Attribute()
-UnsignedAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+UnsignedAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class SignerIdentifier(univ.Choice):
@@ -637,7 +637,7 @@ class AuthAttributes(univ.SetOf):
 
 
 AuthAttributes.componentType = Attribute()
-AuthAttributes.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+AuthAttributes.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class Time(univ.Choice):

--- a/pyasn1_modules/rfc5958.py
+++ b/pyasn1_modules/rfc5958.py
@@ -84,7 +84,7 @@ class AsymmetricKeyPackage(univ.SequenceOf):
     pass
 
 AsymmetricKeyPackage.componentType = OneAsymmetricKey()
-AsymmetricKeyPackage.subtypeSpec=constraint.ValueSizeConstraint(1, MAX)
+AsymmetricKeyPackage.sizeSpec=constraint.ValueSizeConstraint(1, MAX)
     
 
 # Map of Content Type OIDs to Content Types

--- a/pyasn1_modules/rfc6402.py
+++ b/pyasn1_modules/rfc6402.py
@@ -97,7 +97,7 @@ class BodyPartPath(univ.SequenceOf):
 
 
 BodyPartPath.componentType = BodyPartID()
-BodyPartPath.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+BodyPartPath.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class BodyPartReference(univ.Choice):
@@ -425,7 +425,7 @@ class BodyPartList(univ.SequenceOf):
 
 
 BodyPartList.componentType = BodyPartID()
-BodyPartList.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+BodyPartList.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 id_cmc_responseBody = _buildOid(id_cmc, 37)
 
@@ -490,7 +490,7 @@ class ExtensionReq(univ.SequenceOf):
 
 
 ExtensionReq.componentType = rfc5280.Extension()
-ExtensionReq.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
+ExtensionReq.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 id_kp_cmcArchive = _buildOid(rfc5280.id_kp, 28)
 

--- a/pyasn1_modules/rfc7191.py
+++ b/pyasn1_modules/rfc7191.py
@@ -75,7 +75,7 @@ class SIREntityNames(univ.SequenceOf):
     pass
 
 SIREntityNames.componentType = SIREntityName()
-SIREntityNames.subtypeSpec=constraint.ValueSizeConstraint(1, MAX)
+SIREntityNames.sizeSpec=constraint.ValueSizeConstraint(1, MAX)
 
 
 id_dn = univ.ObjectIdentifier('2.16.840.1.101.2.1.16.0')

--- a/pyasn1_modules/rfc8226.py
+++ b/pyasn1_modules/rfc8226.py
@@ -41,7 +41,7 @@ class JWTClaimNames(univ.SequenceOf):
     pass
 
 JWTClaimNames.componentType = JWTClaimName()
-JWTClaimNames.subtypeSpec=constraint.ValueSizeConstraint(1, MAX)
+JWTClaimNames.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class JWTClaimPermittedValues(univ.Sequence):
@@ -51,7 +51,7 @@ JWTClaimPermittedValues.componentType = namedtype.NamedTypes(
     namedtype.NamedType('claim', JWTClaimName()),
     namedtype.NamedType('permitted', univ.SequenceOf(
         componentType=char.UTF8String()).subtype(
-            subtypeSpec=constraint.ValueSizeConstraint(1, MAX)))
+            sizeSpec=constraint.ValueSizeConstraint(1, MAX)))
 )
 
 
@@ -59,7 +59,7 @@ class JWTClaimPermittedValuesList(univ.SequenceOf):
     pass
 
 JWTClaimPermittedValuesList.componentType = JWTClaimPermittedValues()
-JWTClaimPermittedValuesList.subtypeSpec=constraint.ValueSizeConstraint(1, MAX)
+JWTClaimPermittedValuesList.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 
 class JWTClaimConstraints(univ.Sequence):
@@ -125,8 +125,7 @@ class TNAuthorizationList(univ.SequenceOf):
     pass
 
 TNAuthorizationList.componentType = TNEntry()
-TNAuthorizationList.subtypeSpec=constraint.ValueSizeConstraint(1, MAX)
-
+TNAuthorizationList.sizeSpec = constraint.ValueSizeConstraint(1, MAX)
 
 id_pe_TNAuthList = _OID(1, 3, 6, 1, 5, 5, 7, 1, 26)
 

--- a/tests/test_rfc2315.py
+++ b/tests/test_rfc2315.py
@@ -155,12 +155,12 @@ Kv0xuR3b3Le+ZqolT8wQELd5Mmw5JPofZ+O2cGNvet8tYwOKFjEA
     def testDerCodecDecodeOpenTypes(self):
 
         substrate = pem.readBase64fromText(self.pem_text_reordered)
-
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encoder.encode(
+            asn1Object, omitEmptyOptionals=False) == substrate
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc2986.py
+++ b/tests/test_rfc2986.py
@@ -60,7 +60,7 @@ fi6h7i9VVAZpslaKFfkNg12gLbbsCB1q36l5VXjHY/qe0FIUa9ogRrOi
         algorithmIdentifierMapUpdate = {
             univ.ObjectIdentifier('1.2.840.113549.1.1.1'): univ.Null(""),
             univ.ObjectIdentifier('1.2.840.113549.1.1.5'): univ.Null(""),
-           univ.ObjectIdentifier('1.2.840.113549.1.1.11'): univ.Null(""),
+            univ.ObjectIdentifier('1.2.840.113549.1.1.11'): univ.Null(""),
         }
 
         rfc5280.algorithmIdentifierMap.update(algorithmIdentifierMapUpdate)
@@ -70,6 +70,7 @@ fi6h7i9VVAZpslaKFfkNg12gLbbsCB1q36l5VXjHY/qe0FIUa9ogRrOi
             decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
+
         assert der_encoder.encode(asn1Object) == substrate
 
         for rdn in asn1Object['certificationRequestInfo']['subject']['rdnSequence']:

--- a/tests/test_rfc5652.py
+++ b/tests/test_rfc5652.py
@@ -73,7 +73,6 @@ xicQmJP+VoMHo/ZpjFY9fYCjNZUArgKsEwK/s+p9yrVVeB1Nf8Mn
             rfc6402.id_cct_PKIData: lambda x: None
         }
 
-
         next_layer = rfc5652.id_ct_contentInfo
 
         while next_layer:


### PR DESCRIPTION
Changes `ValueSizeConstraint` erroneously applied to `SequenceOf`
and `SetOf` objects via `subtypeConstraint` attribute to be applied
via `sizeSpec` attribute.

Although `sizeSpec` takes the same constraint objects as
`subtypeConstraint`, the former is only verified on de/serialization
i.e. when the [constructed] object at hand is fully populated, while
the latter is applied to [scalar] types at the moment of instantiation.

This change also bumps pyasn1 requirement to 0.4.6.