### PR TITLE
Add openType support in the RFC5652 module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,8 @@ Revision 0.2.6, released XX-07-2019
   Algorithm Identifiers in the RFC5280 module
 - Added RFC5035 providing Update to Enhanced Security Services for
   S/MIME
+- Added openType support for CMS Content Types and CMS Attributes
+  in the RFC5652 module
 
 Revision 0.2.5, released 24-04-2019
 -----------------------------------

--- a/pyasn1_modules/rfc5652.py
+++ b/pyasn1_modules/rfc5652.py
@@ -3,6 +3,8 @@
 # This file is part of pyasn1-modules software.
 #
 # Created by Stanisław Pitucha with asn1ate tool.
+# Modified by Russ Housley to add support for opentypes.
+#
 # Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
 # License: http://snmplabs.com/pyasn1/license.html
 #
@@ -14,6 +16,7 @@
 from pyasn1.type import constraint
 from pyasn1.type import namedtype
 from pyasn1.type import namedval
+from pyasn1.type import opentype
 from pyasn1.type import tag
 from pyasn1.type import univ
 from pyasn1.type import useful
@@ -33,6 +36,19 @@ def _buildOid(*components):
             output.append(int(x))
 
     return univ.ObjectIdentifier(output)
+
+
+cmsContentTypesMap = { }
+
+cmsAttributesMap = { }
+
+otherKeyAttributesMap = { }
+
+otherCertFormatMap = { }
+
+otherRevInfoFormatMap = { }
+
+otherRecipientInfoMap = { }
 
 
 class AttCertVersionV1(univ.Integer):
@@ -89,7 +105,9 @@ class Attribute(univ.Sequence):
 
 Attribute.componentType = namedtype.NamedTypes(
     namedtype.NamedType('attrType', univ.ObjectIdentifier()),
-    namedtype.NamedType('attrValues', univ.SetOf(componentType=AttributeValue()))
+    namedtype.NamedType('attrValues', univ.SetOf(componentType=AttributeValue()),
+        openType=opentype.OpenType('attrType', cmsAttributesMap)
+    )
 )
 
 
@@ -111,7 +129,9 @@ class OtherKeyAttribute(univ.Sequence):
 
 OtherKeyAttribute.componentType = namedtype.NamedTypes(
     namedtype.NamedType('keyAttrId', univ.ObjectIdentifier()),
-    namedtype.OptionalNamedType('keyAttr', univ.Any())
+    namedtype.OptionalNamedType('keyAttr', univ.Any(),
+        openType=opentype.OpenType('keyAttrId', otherKeyAttributesMap)
+    )
 )
 
 
@@ -210,7 +230,9 @@ class OtherCertificateFormat(univ.Sequence):
 
 OtherCertificateFormat.componentType = namedtype.NamedTypes(
     namedtype.NamedType('otherCertFormat', univ.ObjectIdentifier()),
-    namedtype.NamedType('otherCert', univ.Any())
+    namedtype.NamedType('otherCert', univ.Any(),
+        openType=opentype.OpenType('otherCertFormat', otherCertFormatMap)
+    )
 )
 
 
@@ -274,7 +296,9 @@ class OtherRevocationInfoFormat(univ.Sequence):
 
 OtherRevocationInfoFormat.componentType = namedtype.NamedTypes(
     namedtype.NamedType('otherRevInfoFormat', univ.ObjectIdentifier()),
-    namedtype.NamedType('otherRevInfo', univ.Any())
+    namedtype.NamedType('otherRevInfo', univ.Any(),
+        openType=opentype.OpenType('otherRevInfoFormat', otherRevInfoFormatMap)
+    )
 )
 
 
@@ -455,7 +479,9 @@ class OtherRecipientInfo(univ.Sequence):
 
 OtherRecipientInfo.componentType = namedtype.NamedTypes(
     namedtype.NamedType('oriType', univ.ObjectIdentifier()),
-    namedtype.NamedType('oriValue', univ.Any())
+    namedtype.NamedType('oriValue', univ.Any(),
+        openType=opentype.OpenType('oriType', otherRecipientInfoMap)
+    )
 )
 
 
@@ -581,7 +607,9 @@ class ContentInfo(univ.Sequence):
 
 ContentInfo.componentType = namedtype.NamedTypes(
     namedtype.NamedType('contentType', ContentType()),
-    namedtype.NamedType('content', univ.Any().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
+    namedtype.NamedType('content', univ.Any().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)),
+        openType=opentype.OpenType('contentType', cmsContentTypesMap)
+    )
 )
 
 
@@ -704,3 +732,30 @@ class SigningTime(Time):
 
 
 id_ct_authData = _buildOid(1, 2, 840, 113549, 1, 9, 16, 1, 2)
+
+
+# CMS Content Type Map
+
+_cmsContentTypesMapUpdate = {
+    id_ct_contentInfo: ContentInfo(),
+    id_data: univ.OctetString(),
+    id_signedData: SignedData(),
+    id_envelopedData: EnvelopedData(),
+    id_digestedData: DigestedData(),
+    id_encryptedData: EncryptedData(),
+    id_ct_authData: AuthenticatedData(),
+}
+
+cmsContentTypesMap.update(_cmsContentTypesMapUpdate)
+
+
+# CMS Attribute Map
+
+_cmsAttributesMapUpdate = {
+    id_contentType: ContentType(),
+    id_messageDigest: MessageDigest(),
+    id_signingTime: SigningTime(),
+    id_countersignature: Countersignature(),
+}
+
+cmsAttributesMap.update(_cmsAttributesMapUpdate)

--- a/tests/test_rfc5652.py
+++ b/tests/test_rfc5652.py
@@ -9,7 +9,12 @@ import sys
 from pyasn1.codec.der import decoder as der_decoder
 from pyasn1.codec.der import encoder as der_encoder
 
+from pyasn1.type import char
+from pyasn1.type import namedtype
+from pyasn1.type import univ
+
 from pyasn1_modules import pem
+from pyasn1_modules import rfc5280
 from pyasn1_modules import rfc5652
 from pyasn1_modules import rfc6402
 
@@ -83,6 +88,83 @@ xicQmJP+VoMHo/ZpjFY9fYCjNZUArgKsEwK/s+p9yrVVeB1Nf8Mn
 
             substrate = getNextSubstrate[next_layer](asn1Object)
             next_layer = getNextLayer[next_layer](asn1Object)
+
+    def testOpenTypes(self):
+        class ClientInformation(univ.Sequence):
+            pass
+
+        ClientInformation.componentType = namedtype.NamedTypes(
+            namedtype.NamedType('clientId', univ.Integer()),
+            namedtype.NamedType('MachineName', char.UTF8String()),
+            namedtype.NamedType('UserName', char.UTF8String()),
+            namedtype.NamedType('ProcessName', char.UTF8String())
+        )
+
+        class EnrollmentCSP(univ.Sequence):
+            pass
+
+        EnrollmentCSP.componentType = namedtype.NamedTypes(
+            namedtype.NamedType('KeySpec', univ.Integer()),
+            namedtype.NamedType('Name', char.BMPString()),
+            namedtype.NamedType('Signature', univ.BitString())
+        )
+
+        attributesMapUpdate = {
+            univ.ObjectIdentifier('1.3.6.1.4.1.311.13.2.3'): char.IA5String(),
+            univ.ObjectIdentifier('1.3.6.1.4.1.311.13.2.2'): EnrollmentCSP(),
+            univ.ObjectIdentifier('1.3.6.1.4.1.311.21.20'): ClientInformation(),
+        }
+
+        rfc5652.cmsAttributesMap.update(rfc6402.cmcControlAttributesMap)
+        rfc5652.cmsAttributesMap.update(attributesMapUpdate)
+
+        algorithmIdentifierMapUpdate = {
+            univ.ObjectIdentifier('1.2.840.113549.1.1.1'): univ.Null(""),
+            univ.ObjectIdentifier('1.2.840.113549.1.1.5'): univ.Null(""),
+            univ.ObjectIdentifier('1.2.840.113549.1.1.11'): univ.Null(""),
+        }
+
+        rfc5280.algorithmIdentifierMap.update(algorithmIdentifierMapUpdate)
+
+        rfc5652.cmsContentTypesMap.update(rfc6402.cmsContentTypesMapUpdate)
+
+        substrate = pem.readBase64fromText(self.pem_text)
+
+        asn1Object, rest = der_decoder.decode(substrate,
+            asn1Spec=rfc5652.ContentInfo(), decodeOpenTypes=True)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encoder.encode(asn1Object) == substrate
+
+        eci = asn1Object['content']['encapContentInfo']
+        assert eci['eContentType'] in rfc5652.cmsContentTypesMap.keys()
+        assert eci['eContentType'] == rfc6402.id_cct_PKIData
+        pkid, rest = der_decoder.decode(eci['eContent'],
+            asn1Spec=rfc5652.cmsContentTypesMap[eci['eContentType']],
+            decodeOpenTypes=True)
+        assert not rest
+        assert pkid.prettyPrint()
+        assert der_encoder.encode(pkid) == eci['eContent']
+
+        for req in pkid['reqSequence']:
+            cr = req['tcr']['certificationRequest']
+
+            sig_alg = cr['signatureAlgorithm']
+            assert sig_alg['algorithm'] in rfc5280.algorithmIdentifierMap.keys()
+            assert sig_alg['parameters'] == univ.Null("")
+
+            cri = cr['certificationRequestInfo']
+            spki_alg = cri['subjectPublicKeyInfo']['algorithm']
+            assert spki_alg['algorithm'] in rfc5280.algorithmIdentifierMap.keys()
+            assert spki_alg['parameters'] == univ.Null("")
+
+            attrs = cr['certificationRequestInfo']['attributes']
+            for attr in attrs:
+                assert attr['attrType'] in rfc5652.cmsAttributesMap.keys()
+                if attr['attrType'] == univ.ObjectIdentifier('1.3.6.1.4.1.311.13.2.3'):
+                    assert attr['attrValues'][0] == "6.2.9200.2"
+                else:
+                    assert attr['attrValues'][0].hasValue()
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
Add openType support for CMS Content Types and CMS Attributes in the RFC5652 module.  Also added a related test.