### PR TITLE
Add support for opentype for RFC 2986

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,8 @@ Revision 0.2.6, released XX-07-2019
   S/MIME
 - Added openType support for CMS Content Types and CMS Attributes
   in the RFC5652 module
+- Added openType support to RFC 2986 by importing definitions from
+  the RFC 5280 module so that the same maps are used.
 
 Revision 0.2.5, released 24-04-2019
 -----------------------------------

--- a/pyasn1_modules/rfc2986.py
+++ b/pyasn1_modules/rfc2986.py
@@ -3,117 +3,67 @@
 # This file is part of pyasn1-modules software.
 #
 # Created by Joel Johnson with asn1ate tool.
+# Modified by Russ Housley to add support for opentypes by importing
+#   definitions from rfc5280 so that the same maps are used.
+#
 # Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
 # License: http://snmplabs.com/pyasn1/license.html
 #
 # PKCS #10: Certification Request Syntax Specification
 #
 # ASN.1 source from:
-# http://www.ietf.org/rfc/rfc2986.txt
+# https://www.rfc-editor.org/rfc/rfc2986.txt
 #
-from pyasn1.type import constraint
 from pyasn1.type import namedtype
-from pyasn1.type import opentype
 from pyasn1.type import tag
 from pyasn1.type import univ
+
+from pyasn1_modules import rfc5280
 
 MAX = float('inf')
 
 
-class AttributeType(univ.ObjectIdentifier):
-    pass
+AttributeType = rfc5280.AttributeType
 
+AttributeValue = rfc5280.AttributeValue
 
-class AttributeValue(univ.Any):
-    pass
+AttributeTypeAndValue = rfc5280.AttributeTypeAndValue
 
+Attribute = rfc5280.Attribute
 
-certificateAttributesMap = {}
+RelativeDistinguishedName = rfc5280.RelativeDistinguishedName
 
+RDNSequence = rfc5280.RDNSequence
 
-class AttributeTypeAndValue(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('type', AttributeType()),
-        namedtype.NamedType(
-            'value', AttributeValue(),
-            openType=opentype.OpenType('type', certificateAttributesMap)
-        )
-    )
+Name = rfc5280.Name
 
+AlgorithmIdentifier = rfc5280.AlgorithmIdentifier
 
-class Attribute(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('type', AttributeType()),
-        namedtype.NamedType('values',
-                            univ.SetOf(componentType=AttributeValue()),
-                            openType=opentype.OpenType('type', certificateAttributesMap))
-    )
+SubjectPublicKeyInfo = rfc5280.SubjectPublicKeyInfo
 
 
 class Attributes(univ.SetOf):
     pass
 
-
 Attributes.componentType = Attribute()
-
-
-class RelativeDistinguishedName(univ.SetOf):
-    pass
-
-
-RelativeDistinguishedName.componentType = AttributeTypeAndValue()
-RelativeDistinguishedName.subtypeSpec = constraint.ValueSizeConstraint(1, MAX)
-
-
-class RDNSequence(univ.SequenceOf):
-    pass
-
-
-RDNSequence.componentType = RelativeDistinguishedName()
-
-
-class Name(univ.Choice):
-    pass
-
-
-Name.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('rdnSequence', RDNSequence())
-)
-
-
-class AlgorithmIdentifier(univ.Sequence):
-    componentType = namedtype.NamedTypes(
-        namedtype.NamedType('algorithm', univ.ObjectIdentifier()),
-        namedtype.OptionalNamedType('parameters', univ.Any())
-    )
-
-
-class SubjectPublicKeyInfo(univ.Sequence):
-    pass
-
-
-SubjectPublicKeyInfo.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('algorithm', AlgorithmIdentifier()),
-    namedtype.NamedType('subjectPublicKey', univ.BitString())
-)
 
 
 class CertificationRequestInfo(univ.Sequence):
     pass
-
 
 CertificationRequestInfo.componentType = namedtype.NamedTypes(
     namedtype.NamedType('version', univ.Integer()),
     namedtype.NamedType('subject', Name()),
     namedtype.NamedType('subjectPKInfo', SubjectPublicKeyInfo()),
     namedtype.NamedType('attributes',
-                        Attributes().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
+                        Attributes().subtype(implicitTag=tag.Tag(
+                            tag.tagClassContext, tag.tagFormatSimple, 0))
+    )
 )
 
 
 class CertificationRequest(univ.Sequence):
     pass
-
 
 CertificationRequest.componentType = namedtype.NamedTypes(
     namedtype.NamedType('certificationRequestInfo', CertificationRequestInfo()),


### PR DESCRIPTION
Add support for opentypes by importing definitions from rfc5280 so that the same maps are used.  Also added a test for opentypes.