### PR TITLE
Improve opentypes maps for RFC3709, RFC6402, RFC7191, and RFC8226

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ Revision 0.2.7, released XX-08-2019
   Exchange Syntax v1.1
 - Added RFC8018 providing PKCS #5, which is the Password-Based
   Cryptography Specification, Version 2.1
+- Automatically update the maps for use with openType for RFC3709,
+  RFC6402, RFC7191, and RFC8226 when the module is imported
 
 Revision 0.2.6, released 31-07-2019
 -----------------------------------

--- a/pyasn1_modules/rfc3709.py
+++ b/pyasn1_modules/rfc3709.py
@@ -194,9 +194,11 @@ LogotypeExtn.componentType = namedtype.NamedTypes(
 )
 
 
-# Map of Certificate Extension OIDs to Extensions
-# To be added to the ones that are in rfc5280.py
+# Map of Certificate Extension OIDs to Extensions added to the
+# ones that are in rfc5280.py
 
-certificateExtensionsMapUpdate = {
+_certificateExtensionsMapUpdate = {
     id_pe_logotype: LogotypeExtn(),
 }
+
+rfc5280.certificateExtensionsMap.update(_certificateExtensionsMapUpdate)

--- a/pyasn1_modules/rfc6402.py
+++ b/pyasn1_modules/rfc6402.py
@@ -615,10 +615,13 @@ _cmcControlAttributesMapUpdate = {
 cmcControlAttributesMap.update(_cmcControlAttributesMapUpdate)
 
 
-# Map of CMC Content Type OIDs to CMC Content Types
-# To be added to the ones that are in rfc5652.py
+# Map of CMC Content Type OIDs to CMC Content Types are added to
+# the ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+_cmsContentTypesMapUpdate = {
     id_cct_PKIData: PKIData(),
     id_cct_PKIResponse: PKIResponse(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)
+

--- a/pyasn1_modules/rfc7191.py
+++ b/pyasn1_modules/rfc7191.py
@@ -240,18 +240,22 @@ KeyPkgIdentifierAndReceiptReq.componentType = namedtype.NamedTypes(
 )
 
 
-# Map of Attribute Type OIDs to Attributes
-# To be added to the ones that are in rfc5652.py
+# Map of Attribute Type OIDs to Attributes are added to
+# the ones that are in rfc5652.py
 
-cmsAttributesMapUpdate = {
+_cmsAttributesMapUpdate = {
     id_aa_KP_keyPkgIdAndReceiptReq: KeyPkgIdentifierAndReceiptReq(),
 }
 
+rfc5652.cmsAttributesMap.update(_cmsAttributesMapUpdate)
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+# Map of CMC Content Type OIDs to CMC Content Types are added to
+# the ones that are in rfc5652.py
+
+_cmsContentTypesMapUpdate = {
     id_ct_KP_keyPackageError: KeyPackageError(),
     id_ct_KP_keyPackageReceipt: KeyPackageReceipt(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)

--- a/pyasn1_modules/rfc8226.py
+++ b/pyasn1_modules/rfc8226.py
@@ -18,6 +18,7 @@ from pyasn1.type import namedtype
 from pyasn1.type import tag
 from pyasn1.type import univ
 
+from pyasn1_modules import rfc5280
 
 MAX = float('inf')
 
@@ -133,11 +134,12 @@ id_pe_TNAuthList = _OID(1, 3, 6, 1, 5, 5, 7, 1, 26)
 id_ad_stirTNList = _OID(1, 3, 6, 1, 5, 5, 7, 48, 14)
 
 
-# Map of Certificate Extension OIDs to Extensions
-# To be added to the ones that are in rfc5280.py
+# Map of Certificate Extension OIDs to Extensions added to the
+# ones that are in rfc5280.py
 
-certificateExtensionsMapUpdate = {
+_certificateExtensionsMapUpdate = {
     id_pe_TNAuthList: TNAuthorizationList(),
     id_pe_JWTClaimConstraints: JWTClaimConstraints(),
 }
 
+rfc5280.certificateExtensionsMap.update(_certificateExtensionsMapUpdate)

--- a/tests/test_rfc3709.py
+++ b/tests/test_rfc3709.py
@@ -66,7 +66,6 @@ Pj22pmfmQi5w21UljqoTj/+lQLkU3wfy5BdVKBwI0GfEA+YL3ctSzPNqAA==
 
     def testExtensionsMap(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        rfc5280.certificateExtensionsMap.update(rfc3709.certificateExtensionsMapUpdate)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
         assert not rest
         assert asn1Object.prettyPrint()

--- a/tests/test_rfc5652.py
+++ b/tests/test_rfc5652.py
@@ -125,8 +125,6 @@ xicQmJP+VoMHo/ZpjFY9fYCjNZUArgKsEwK/s+p9yrVVeB1Nf8Mn
 
         rfc5280.algorithmIdentifierMap.update(algorithmIdentifierMapUpdate)
 
-        rfc5652.cmsContentTypesMap.update(rfc6402.cmsContentTypesMapUpdate)
-
         substrate = pem.readBase64fromText(self.pem_text)
 
         asn1Object, rest = der_decoder.decode(substrate,

--- a/tests/test_rfc6402.py
+++ b/tests/test_rfc6402.py
@@ -50,8 +50,6 @@ xicQmJP+VoMHo/ZpjFY9fYCjNZUArgKsEwK/s+p9yrVVeB1Nf8Mn
 """
 
     def testDerCodec(self):
-
-        rfc5652.cmsContentTypesMap.update(rfc6402.cmsContentTypesMapUpdate)
         layers = rfc5652.cmsContentTypesMap
 
         getNextLayer = {
@@ -115,8 +113,6 @@ xicQmJP+VoMHo/ZpjFY9fYCjNZUArgKsEwK/s+p9yrVVeB1Nf8Mn
         }
 
         rfc5280.algorithmIdentifierMap.update(algorithmIdentifierMapUpdate)
-
-        rfc5652.cmsContentTypesMap.update(rfc6402.cmsContentTypesMapUpdate)
 
         substrate = pem.readBase64fromText(self.pem_text)
         asn1Object, rest = der_decode(substrate,

--- a/tests/test_rfc7191.py
+++ b/tests/test_rfc7191.py
@@ -89,7 +89,6 @@ goRV+bq4fdgOOj25JFqa80xnXGtQqjm/7NSII5SbdJk+DT7KCkSbkElkbgQ=
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.message1_pem_text)
-        rfc5652.cmsAttributesMap.update(rfc7191.cmsAttributesMapUpdate)
         asn1Object, rest = der_decode (substrate,
                                        asn1Spec=self.asn1Spec,
                                        decodeOpenTypes=True)
@@ -165,8 +164,6 @@ bUcOYuCdivgxVuhlAgIxAPR9JavxziwCbVyBUWOAiKKYfglTgG3AwNmrKDj0NtXUQ9qDmGAc
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.message2_pem_text)
-        rfc5652.cmsContentTypesMap.update(rfc7191.cmsContentTypesMapUpdate)
-        rfc5652.cmsAttributesMap.update(rfc7191.cmsAttributesMapUpdate)
         asn1Object, rest = der_decode (substrate,
                                        asn1Spec=self.asn1Spec,
                                        decodeOpenTypes=True)
@@ -254,8 +251,6 @@ iNF8uKtW/lk0AjA7z2q40N0lamXkSU7ECasiWOYV1X4cWGiQwMZDKknBPDqXqB6Es6p4J+qe
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.message3_pem_text)
-        rfc5652.cmsContentTypesMap.update(rfc7191.cmsContentTypesMapUpdate)
-        rfc5652.cmsAttributesMap.update(rfc7191.cmsAttributesMapUpdate)
         asn1Object, rest = der_decode (substrate,
                                        asn1Spec=self.asn1Spec,
                                        decodeOpenTypes=True)


### PR DESCRIPTION
Automatically update the maps for use with openTypes for RFC3709, RFC6402, RFC7191, and RFC8226 when the module is imported.  Adjust the tests to match.