### PR TITLE
Updates to RFC2459, RFC5280, and RFC6211

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,7 @@ Revision 0.2.7, released XX-08-2019
   RFC6402, RFC7191, and RFC8226 when the module is imported
 - Added RFC6211 providing CMS Algorithm Identifier Protection Attribute
 - Added RFC8449 providing Certificate Extension for Hash Of Root Key
+- Updated RFC2459 and RFC5280 for TODO in the certificate extension map
 
 Revision 0.2.6, released 31-07-2019
 -----------------------------------

--- a/pyasn1_modules/rfc2459.py
+++ b/pyasn1_modules/rfc2459.py
@@ -1,6 +1,9 @@
 #
 # This file is part of pyasn1-modules software.
 #
+# Updated by Russ Housley to resolve the TODO regarding the Certificate
+#   Policies Certificate Extension.
+#
 # Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
 # License: http://snmplabs.com/pyasn1/license.html
 #
@@ -1312,8 +1315,7 @@ _certificateExtensionsMapUpdate = {
     id_ce_subjectKeyIdentifier: SubjectKeyIdentifier(),
     id_ce_keyUsage: KeyUsage(),
     id_ce_privateKeyUsagePeriod: PrivateKeyUsagePeriod(),
-# TODO
-#    id_ce_certificatePolicies: PolicyInformation(),  # could be a sequence of concat'ed objects?
+    id_ce_certificatePolicies: CertificatePolicies(),
     id_ce_policyMappings: PolicyMappings(),
     id_ce_subjectAltName: SubjectAltName(),
     id_ce_issuerAltName: IssuerAltName(),

--- a/pyasn1_modules/rfc5280.py
+++ b/pyasn1_modules/rfc5280.py
@@ -1635,7 +1635,7 @@ _certificateExtensionsMap = {
     id_ce_subjectKeyIdentifier: SubjectKeyIdentifier(),
     id_ce_keyUsage: KeyUsage(),
     id_ce_privateKeyUsagePeriod: PrivateKeyUsagePeriod(),
-    id_ce_certificatePolicies: PolicyInformation(),  # could be a sequence of concat'ed objects?
+    id_ce_certificatePolicies: CertificatePolicies(),
     id_ce_policyMappings: PolicyMappings(),
     id_ce_subjectAltName: SubjectAltName(),
     id_ce_issuerAltName: IssuerAltName(),

--- a/pyasn1_modules/rfc6211.py
+++ b/pyasn1_modules/rfc6211.py
@@ -47,16 +47,14 @@ CMSAlgorithmProtection.componentType = namedtype.NamedTypes(
             implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)))
 )
 
-# TODO: Add constraints to implement the WITH COMPONENTS part of the ASN.1:
-#
-# CMSAlgorithmProtection.subtypeSpec = constraint.ConstraintsIntersection(
-#     constraint.WithComponentsConstraint(
-#         ('signatureAlgorithm', constraint.ComponentPresentConstraint()),
-#         ('macAlgorithm', constraint.ComponentAbsentConstraint())),
-#     constraint.WithComponentsConstraint(
-#         ('signatureAlgorithm', constraint.ComponentAbsentConstraint()),
-#         ('macAlgorithm', constraint.ComponentPresentConstraint()))
-# )
+CMSAlgorithmProtection.subtypeSpec = constraint.ConstraintsUnion(
+    constraint.WithComponentsConstraint(
+        ('signatureAlgorithm', constraint.ComponentPresentConstraint()),
+        ('macAlgorithm', constraint.ComponentAbsentConstraint())),
+    constraint.WithComponentsConstraint(
+        ('signatureAlgorithm', constraint.ComponentAbsentConstraint()),
+        ('macAlgorithm', constraint.ComponentPresentConstraint()))
+)
 
 
 aa_cmsAlgorithmProtection = rfc5652.Attribute()


### PR DESCRIPTION
This depends on the yet-to-be-released pyasn1 implementation of WithComponentsConstraint.  Please adjust the requirements.txt once pyasn1 is released.

Updates RFC6211 to use WithComponentsConstraint.

Updates RFC2459 and RFC5280 for TODO in the certificate extension map.