### PR TITLE
Add support for RFC 3894 and openTypes map cleanup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,11 @@ Revision 0.2.7, released XX-08-2019
 - Added RFC8449 providing Certificate Extension for Hash Of Root Key
 - Updated RFC2459 and RFC5280 for TODO in the certificate extension map
 - Added RFC7906 providing NSA's CMS Key Management Attributes
+- Added RFC7894 providing EST Alternative Challenge Password Attributes
+- Updated the handling of maps for use with openType so that just doing
+  an import of the modules is enough in most situations; updates to
+  RFC 2634, RFC 3274, RFC 3779, RFC 4073, RFC 4108, RFC 5035, RFC 5083,
+  RFC 5084, RFC 5480, RFC 5940, RFC 5958, RFC 6019, and RFC 8520
 
 Revision 0.2.6, released 31-07-2019
 -----------------------------------

--- a/pyasn1_modules/rfc2634.py
+++ b/pyasn1_modules/rfc2634.py
@@ -308,9 +308,10 @@ Receipt.componentType = namedtype.NamedTypes(
 )
 
 
-# Map of Attribute Type to the Attribute structure
+# Map of Attribute Type to the Attribute structure is added to the
+# ones that are in rfc5652.py
 
-ESSAttributeMap = {
+_cmsAttributesMapUpdate = {
     id_aa_signingCertificate: SigningCertificate(),
     id_aa_mlExpandHistory: MLExpansionHistory(),
     id_aa_securityLabel: ESSSecurityLabel(),
@@ -322,10 +323,14 @@ ESSAttributeMap = {
     id_aa_receiptRequest: ReceiptRequest(),
 }
 
+rfc5652.cmsAttributesMap.update(_cmsAttributesMapUpdate)
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+# Map of Content Type OIDs to Content Types is added to the
+# ones that are in rfc5652.py
+
+_cmsContentTypesMapUpdate = {
     id_ct_receipt: Receipt(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)

--- a/pyasn1_modules/rfc2985.py
+++ b/pyasn1_modules/rfc2985.py
@@ -536,7 +536,7 @@ smimeCapabilities['attrValues'][0] = SMIMECapabilities()
 
 # Certificate Attribute Map
 
-certificateAttributesMapUpdate = {
+_certificateAttributesMapUpdate = {
     # Attribute types for use with the "pkcsEntity" object class
     pkcs_9_at_pkcs7PDU: ContentInfo(),
     pkcs_9_at_userPKCS12: PFX(),
@@ -560,12 +560,12 @@ certificateAttributesMapUpdate = {
     pkcs_9_at_extendedCertificateAttributes: AttributeSet(),
 }
 
-rfc5280.certificateAttributesMap.update(certificateAttributesMapUpdate)
+rfc5280.certificateAttributesMap.update(_certificateAttributesMapUpdate)
 
 
 # CMS Attribute Map
 
-cmsAttributesMapUpdate = {
+_cmsAttributesMapUpdate = {
     # Attribute types for use in PKCS #7 data (a.k.a. CMS)
     pkcs_9_at_contentType: ContentType(),
     pkcs_9_at_messageDigest: MessageDigest(),
@@ -580,4 +580,4 @@ cmsAttributesMapUpdate = {
     pkcs_9_at_smimeCapabilities: SMIMECapabilities(),
 }
 
-rfc5652.cmsAttributesMap.update(cmsAttributesMapUpdate)
+rfc5652.cmsAttributesMap.update(_cmsAttributesMapUpdate)

--- a/pyasn1_modules/rfc3274.py
+++ b/pyasn1_modules/rfc3274.py
@@ -49,9 +49,11 @@ cpa_zlibCompress['algorithm'] = id_alg_zlibCompress
 # cpa_zlibCompress['parameters'] are absent
 
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
+# Map of Content Type OIDs to Content Types is added to thr
+# ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+_cmsContentTypesMapUpdate = {
     id_ct_compressedData: CompressedData(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)

--- a/pyasn1_modules/rfc3779.py
+++ b/pyasn1_modules/rfc3779.py
@@ -18,6 +18,8 @@ from pyasn1.type import namedtype
 from pyasn1.type import tag
 from pyasn1.type import univ
 
+from pyasn1_modules import rfc5280
+
 
 # IP Address Delegation Extension
 
@@ -124,10 +126,12 @@ ASIdentifiers.componentType = namedtype.NamedTypes(
 )
 
 
-# Map of Certificate Extension OIDs to Extensions
-# To be added to the ones that are in rfc5280.py
+# Map of Certificate Extension OIDs to Extensions is added to the
+# ones that are in rfc5280.py
 
-certificateExtensionsMapUpdate = {
+_certificateExtensionsMapUpdate = {
     id_pe_ipAddrBlocks: IPAddrBlocks(),
     id_pe_autonomousSysIds: ASIdentifiers(),
 }
+
+rfc5280.certificateExtensionsMap.update(_certificateExtensionsMapUpdate)

--- a/pyasn1_modules/rfc4073.py
+++ b/pyasn1_modules/rfc4073.py
@@ -48,10 +48,12 @@ ContentWithAttributes.componentType = namedtype.NamedTypes(
 )
 
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
+# Map of Content Type OIDs to Content Types is added to the
+# ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+_cmsContentTypesMapUpdate = {
     id_ct_contentCollection: ContentCollection(),
     id_ct_contentWithAttrs: ContentWithAttributes(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)

--- a/pyasn1_modules/rfc4108.py
+++ b/pyasn1_modules/rfc4108.py
@@ -310,10 +310,10 @@ HardwareModuleName.componentType = namedtype.NamedTypes(
 )
 
 
-# Map of Attribute Type OIDs to Attributes
-# To be added to the ones that are in rfc5652.py
+# Map of Attribute Type OIDs to Attributes is added to the
+# ones that are in rfc5652.py
 
-cmsAttributesMapUpdate = {
+_cmsAttributesMapUpdate = {
     id_aa_wrappedFirmwareKey: WrappedFirmwareKey(),
     id_aa_firmwarePackageInfo: FirmwarePackageInfo(),
     id_aa_communityIdentifiers: CommunityIdentifiers(),
@@ -325,21 +325,26 @@ cmsAttributesMapUpdate = {
     id_aa_fwPkgMessageDigest: FirmwarePackageMessageDigest(),
 }
 
+rfc5652.cmsAttributesMap.update(_cmsAttributesMapUpdate)
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+# Map of Content Type OIDs to Content Types is added to the
+# ones that are in rfc5652.py
+
+_cmsContentTypesMapUpdate = {
     id_ct_firmwareLoadError: FirmwarePackageLoadError(),
     id_ct_firmwareLoadReceipt: FirmwarePackageLoadReceipt(),
     id_ct_firmwarePackage: FirmwarePkgData(),
 }
 
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)
 
-# Map of Other Name OIDs to Other Name
-# To be added to the ones that are in rfc5280.py
 
-anotherNameMapUpdate = {
+# Map of Other Name OIDs to Other Name is added to the
+# ones that are in rfc5280.py
+
+_anotherNameMapUpdate = {
     id_on_hardwareModuleName: HardwareModuleName(),
 }
 
+rfc5280.anotherNameMap.update(_anotherNameMapUpdate)

--- a/pyasn1_modules/rfc5035.py
+++ b/pyasn1_modules/rfc5035.py
@@ -179,20 +179,21 @@ ub_receiptsTo = rfc2634.ub_receiptsTo
 ReceiptRequest = rfc2634.ReceiptRequest
 
 
-# Map of Attribute Type to the Attribute structure
+# Map of Attribute Type to the Attribute structure is added to the
+# ones that are in rfc5652.py
 
-ESSAttributeMap = rfc2634.ESSAttributeMap
-
-_ESSAttributeMapAddition = {
+_cmsAttributesMapUpdate = {
     id_aa_signingCertificateV2: SigningCertificateV2(),
 }
 
-ESSAttributeMap.update(_ESSAttributeMapAddition)
+rfc5652.cmsAttributesMap.update(_cmsAttributesMapUpdate)
 
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
+# Map of Content Type OIDs to Content Types is added to the
+# ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+_cmsContentTypesMapUpdate = {
     id_ct_receipt: Receipt(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)

--- a/pyasn1_modules/rfc5083.py
+++ b/pyasn1_modules/rfc5083.py
@@ -42,9 +42,11 @@ AuthEnvelopedData.componentType = namedtype.NamedTypes(
 )
 
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
+# Map of Content Type OIDs to Content Types is added to the
+# ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+_cmsContentTypesMapUpdate = {
     id_ct_authEnvelopedData: AuthEnvelopedData(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)

--- a/pyasn1_modules/rfc5084.py
+++ b/pyasn1_modules/rfc5084.py
@@ -16,6 +16,8 @@ from pyasn1.type import constraint
 from pyasn1.type import namedtype
 from pyasn1.type import univ
 
+from pyasn1_modules import rfc5280
+
 
 def _OID(*components):
     output = []
@@ -78,3 +80,18 @@ id_aes192_GCM = _OID(aes, 26)
 id_aes256_CCM = _OID(aes, 47)
 
 id_aes256_GCM = _OID(aes, 46)
+
+
+# Map of Algorithm Identifier OIDs to Parameters is added to the
+# ones in rfc5280.py
+
+_algorithmIdentifierMapUpdate = {
+    id_aes128_CCM: CCMParameters(),
+    id_aes128_GCM: GCMParameters(),
+    id_aes192_CCM: CCMParameters(),
+    id_aes192_GCM: GCMParameters(),
+    id_aes256_CCM: CCMParameters(),
+    id_aes256_GCM: GCMParameters(),
+}
+
+rfc5280.algorithmIdentifierMap.update(_algorithmIdentifierMapUpdate)

--- a/pyasn1_modules/rfc5480.py
+++ b/pyasn1_modules/rfc5480.py
@@ -18,6 +18,7 @@ from pyasn1.type import namedtype
 from pyasn1.type import univ
 
 from pyasn1_modules import rfc3279
+from pyasn1_modules import rfc5280
 
 
 # These structures are the same as RFC 3279.
@@ -170,7 +171,7 @@ sect571r1 = univ.ObjectIdentifier('1.3.132.0.39')
 # Map of Algorithm Identifier OIDs to Parameters
 # The algorithm is not included if the parameters MUST be absent
 
-algorithmIdentifierMapUpdate = {
+_algorithmIdentifierMapUpdate = {
     rsaEncryption: univ.Null(),
     md2WithRSAEncryption: univ.Null(),
     md5WithRSAEncryption: univ.Null(),
@@ -182,3 +183,8 @@ algorithmIdentifierMapUpdate = {
     id_ecDH: ECParameters(),
     id_ecMQV: ECParameters(),
 }
+
+
+# Add these Algorithm Identifier map entries to the ones in rfc5280.py
+
+rfc5280.algorithmIdentifierMap.update(_algorithmIdentifierMapUpdate)

--- a/pyasn1_modules/rfc5940.py
+++ b/pyasn1_modules/rfc5940.py
@@ -42,15 +42,18 @@ class SCVPReqRes(univ.Sequence):
     pass
 
 SCVPReqRes.componentType = namedtype.NamedTypes(
-    namedtype.OptionalNamedType('request', ContentInfo().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+    namedtype.OptionalNamedType('request',
+        ContentInfo().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
     namedtype.NamedType('response', ContentInfo())
 )
 
 
 # Map of Revocation Info Format OIDs to Revocation Info Format
-# To be added to the ones that are in rfc5652.py
+# is added to the ones that are in rfc5652.py
 
-otherRevInfoFormatMapUpdate = {
+_otherRevInfoFormatMapUpdate = {
      id_ri_ocsp_response: OCSPResponse(),
      id_ri_scvp: SCVPReqRes(),
 }
+
+rfc5652.otherRevInfoFormatMap.update(_otherRevInfoFormatMapUpdate)

--- a/pyasn1_modules/rfc5958.py
+++ b/pyasn1_modules/rfc5958.py
@@ -16,6 +16,7 @@
 from pyasn1.type import univ, constraint, namedtype, namedval, tag
 
 from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc5652
 
 
 MAX = float('inf')
@@ -87,9 +88,11 @@ AsymmetricKeyPackage.componentType = OneAsymmetricKey()
 AsymmetricKeyPackage.sizeSpec=constraint.ValueSizeConstraint(1, MAX)
     
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
+# Map of Content Type OIDs to Content Types is added to the
+# ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+_cmsContentTypesMapUpdate = {
     id_ct_KP_aKeyPackage: AsymmetricKeyPackage(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)

--- a/pyasn1_modules/rfc6019.py
+++ b/pyasn1_modules/rfc6019.py
@@ -14,6 +14,8 @@
 from pyasn1.type import constraint
 from pyasn1.type import univ
 
+from pyasn1_modules import rfc5652
+
 MAX = float('inf')
 
 
@@ -33,9 +35,11 @@ class BinarySigningTime(BinaryTime):
     pass
 
 
-# Map of Attribute Type OIDs to Attributes
-# To be added to the ones that are in rfc5652.py
+# Map of Attribute Type OIDs to Attributes ia added to the
+# ones that are in rfc5652.py
 
-cmsAttributesMapUpdate = {
+_cmsAttributesMapUpdate = {
     id_aa_binarySigningTime: BinarySigningTime(),
 }
+
+rfc5652.cmsAttributesMap.update(_cmsAttributesMapUpdate)

--- a/pyasn1_modules/rfc6402.py
+++ b/pyasn1_modules/rfc6402.py
@@ -41,7 +41,8 @@ def _buildOid(*components):
     return univ.ObjectIdentifier(output)
 
 
-cmcControlAttributesMap = { }
+# Since CMS Attributes and CMC Controls both use 'attrType', one map is used 
+cmcControlAttributesMap = rfc5652.cmsAttributesMap
 
 
 class ChangeSubjectName(univ.Sequence):

--- a/pyasn1_modules/rfc7894.py
+++ b/pyasn1_modules/rfc7894.py
@@ -1,0 +1,92 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2019, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Alternative Challenge Password Attributes for EST
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc7894.txt
+#
+
+from pyasn1.type import char
+from pyasn1.type import constraint
+from pyasn1.type import namedtype
+from pyasn1.type import univ
+
+from pyasn1_modules import rfc5652
+from pyasn1_modules import rfc6402
+from pyasn1_modules import rfc7191
+
+
+# SingleAttribute is the same as Attribute in RFC 5652, except that the
+# attrValues SET must have one and only one member
+
+Attribute = rfc7191.SingleAttribute
+
+
+# DirectoryString is the same as RFC 5280, except the length is limited to 255
+
+class DirectoryString(univ.Choice):
+    pass
+
+DirectoryString.componentType = namedtype.NamedTypes(
+    namedtype.NamedType('teletexString', char.TeletexString().subtype(
+        subtypeSpec=constraint.ValueSizeConstraint(1, 255))),
+    namedtype.NamedType('printableString', char.PrintableString().subtype(
+        subtypeSpec=constraint.ValueSizeConstraint(1, 255))),
+    namedtype.NamedType('universalString', char.UniversalString().subtype(
+        subtypeSpec=constraint.ValueSizeConstraint(1, 255))),
+    namedtype.NamedType('utf8String', char.UTF8String().subtype(
+        subtypeSpec=constraint.ValueSizeConstraint(1, 255))),
+    namedtype.NamedType('bmpString', char.BMPString().subtype(
+        subtypeSpec=constraint.ValueSizeConstraint(1, 255)))
+)
+
+
+# OTP Challenge Attribute
+
+id_aa_otpChallenge = univ.ObjectIdentifier('1.2.840.113549.1.9.16.2.56')
+
+ub_aa_otpChallenge = univ.Integer(255)
+
+otpChallenge = Attribute()
+otpChallenge['attrType'] = id_aa_otpChallenge
+otpChallenge['attrValues'][0] = DirectoryString()
+
+
+# Revocation Challenge Attribute
+
+id_aa_revocationChallenge = univ.ObjectIdentifier('1.2.840.113549.1.9.16.2.57')
+
+ub_aa_revocationChallenge = univ.Integer(255)
+
+revocationChallenge = Attribute()
+revocationChallenge['attrType'] = id_aa_revocationChallenge
+revocationChallenge['attrValues'][0] = DirectoryString()
+
+
+#  EST Identity Linking Attribute
+
+id_aa_estIdentityLinking = univ.ObjectIdentifier('1.2.840.113549.1.9.16.2.58')
+
+ub_aa_est_identity_linking = univ.Integer(255)
+
+estIdentityLinking = Attribute()
+estIdentityLinking['attrType'] = id_aa_estIdentityLinking
+estIdentityLinking['attrValues'][0] = DirectoryString()
+
+
+# Map of Attribute Type OIDs to Attributes added to the
+# ones that are in rfc6402.py
+
+_cmcControlAttributesMapUpdate = {
+    id_aa_otpChallenge: DirectoryString(),
+    id_aa_revocationChallenge: DirectoryString(),
+    id_aa_estIdentityLinking: DirectoryString(),
+}
+
+rfc6402.cmcControlAttributesMap.update(_cmcControlAttributesMapUpdate)

--- a/pyasn1_modules/rfc8520.py
+++ b/pyasn1_modules/rfc8520.py
@@ -14,8 +14,11 @@
 # https://www.rfc-editor.org/rfc/rfc8520.txt
 #
 
-from pyasn1.type import univ, char, namedtype, namedval, tag, constraint, useful
+from pyasn1.type import char
+from pyasn1.type import univ
+
 from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc5652
 
 
 # X.509 Extension for MUD URL
@@ -39,18 +42,22 @@ class MUDsignerSyntax(rfc5280.Name):
 id_ct_mudtype = univ.ObjectIdentifier('1.2.840.113549.1.9.16.1.41')
 
 
-# Map of Certificate Extension OIDs to Extensions
-# To be added to the ones that are in rfc5280.py
+# Map of Certificate Extension OIDs to Extensions added to the
+# ones that are in rfc5280.py
 
-certificateExtensionsMapUpdate = {
+_certificateExtensionsMapUpdate = {
     id_pe_mud_url: MUDURLSyntax(),
     id_pe_mudsigner: MUDsignerSyntax(),
 }
 
+rfc5280.certificateExtensionsMap.update(_certificateExtensionsMapUpdate)
 
-# Map of Content Type OIDs to Content Types
-# To be added to the ones that are in rfc5652.py
 
-cmsContentTypesMapUpdate = {
+# Map of Content Type OIDs to Content Types added to the
+# ones that are in rfc5652.py
+
+_cmsContentTypesMapUpdate = {
     id_ct_mudtype: univ.OctetString(),
 }
+
+rfc5652.cmsContentTypesMap.update(_cmsContentTypesMapUpdate)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -53,6 +53,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc7191.suite',
      'tests.test_rfc7292.suite',
      'tests.test_rfc7296.suite',
+     'tests.test_rfc7894.suite',
      'tests.test_rfc7906.suite',
      'tests.test_rfc8018.suite',
      'tests.test_rfc8103.suite',

--- a/tests/test_rfc2634.py
+++ b/tests/test_rfc2634.py
@@ -73,8 +73,8 @@ mNTr0mjYeUWRe/15IsWNx+kuFcLDr71DFHvMFY5M3sdfMA==
             sat = sa['attrType']
             sav0 = sa['attrValues'][0]
 
-            if sat in rfc2634.ESSAttributeMap.keys():
-                sav, rest = der_decode(sav0, asn1Spec=rfc2634.ESSAttributeMap[sat])
+            if sat in rfc5652.cmsAttributesMap.keys():
+                sav, rest = der_decode(sav0, asn1Spec=rfc5652.cmsAttributesMap[sat])
                 assert not rest
                 assert sav.prettyPrint()
                 assert der_encode(sav) == sav0
@@ -139,18 +139,17 @@ lropBdPJ6jIXiZQgCwxbGTCwCMQClaQ9K+L5LTeuW50ZKSIbmBZQ5dxjtnK3OlS
             sat = sa['attrType']
             sav0 = sa['attrValues'][0]
 
-            if sat in rfc2634.ESSAttributeMap.keys():
-                sav, rest = der_decode(sav0, asn1Spec=rfc2634.ESSAttributeMap[sat])
+            if sat in rfc5652.cmsAttributesMap.keys():
+                sav, rest = der_decode(sav0, asn1Spec=rfc5652.cmsAttributesMap[sat])
                 assert not rest
                 assert sav.prettyPrint()
                 assert der_encode(sav) == sav0
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.signed_receipt_pem_text)
-        rfc5652.cmsContentTypesMap.update(rfc2634.cmsContentTypesMapUpdate)
-        rfc5652.cmsAttributesMap.update(rfc2634.ESSAttributeMap)
         asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+            asn1Spec=self.asn1Spec,
+            decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate

--- a/tests/test_rfc2985.py
+++ b/tests/test_rfc2985.py
@@ -129,13 +129,14 @@ HktMK+isIjxOTk4yJTOOAgIH0A==
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate
 
-        rfc5280.certificateAttributesMap.update(rfc2985.certificateAttributesMapUpdate)
-        rfc5280.certificateAttributesMap.update(rfc2985.cmsAttributesMapUpdate)
+        openTypesMap = { }
+        openTypesMap.update(rfc5280.certificateAttributesMap)
+        openTypesMap.update(rfc5652.cmsAttributesMap)
 
         for attr in asn1Object:
-            assert attr['type'] in rfc5280.certificateAttributesMap
+            assert attr['type'] in openTypesMap.keys()
             av, rest = der_decode(attr['values'][0],
-                asn1Spec=rfc5280.certificateAttributesMap[attr['type']])
+                asn1Spec=openTypesMap[attr['type']])
             assert not rest
             assert av.prettyPrint()
             assert der_encode(av) == attr['values'][0]
@@ -166,9 +167,9 @@ HktMK+isIjxOTk4yJTOOAgIH0A==
                             assert not rest
 
                             for bagattr in sb['bagAttributes']:
-                                if bagattr['attrType'] in rfc5280.certificateAttributesMap:
+                                if bagattr['attrType'] in openTypesMap:
                                     inav, rest = der_decode(bagattr['attrValues'][0],
-                                        asn1Spec=rfc5280.certificateAttributesMap[bagattr['attrType']])
+                                        asn1Spec=openTypesMap[bagattr['attrType']])
                                     assert not rest
 
                                     if bagattr['attrType'] == rfc2985.pkcs_9_at_friendlyName:
@@ -192,9 +193,9 @@ HktMK+isIjxOTk4yJTOOAgIH0A==
                     assert si['version'] == 1
 
                     for siattr in si['signedAttrs']:
-                        if siattr['attrType'] in rfc5280.certificateAttributesMap:
+                        if siattr['attrType'] in openTypesMap:
                             siav, rest = der_decode(siattr['attrValues'][0],
-                                asn1Spec=rfc5280.certificateAttributesMap[siattr['attrType']])
+                                asn1Spec=openTypesMap[siattr['attrType']])
                             assert not rest
 
                             if siattr['attrType'] == rfc2985.pkcs_9_at_contentType:
@@ -208,28 +209,30 @@ HktMK+isIjxOTk4yJTOOAgIH0A==
 
                 for choices in sd['certificates']:
                     for rdn in choices[0]['tbsCertificate']['subject']['rdnSequence']:
-                        if rdn[0]['type'] in rfc5280.certificateAttributesMap:
+                        if rdn[0]['type'] in openTypesMap:
                             nv, rest = der_decode(rdn[0]['value'],
-                                 asn1Spec=rfc5280.certificateAttributesMap[rdn[0]['type']])
+                                 asn1Spec=openTypesMap[rdn[0]['type']])
                             assert not rest
 
                             if rdn[0]['type'] == rfc2985.pkcs_9_at_emailAddress:
                                 assert nv == 'alice@example.com'
 
     def testOpenTypes(self):
-        rfc5280.certificateAttributesMap.update(rfc2985.certificateAttributesMapUpdate)
-        rfc5280.certificateAttributesMap.update(rfc2985.cmsAttributesMapUpdate)
+        openTypesMap = { }
+        openTypesMap.update(rfc5280.certificateAttributesMap)
+        openTypesMap.update(rfc5652.cmsAttributesMap)
 
         substrate = pem.readBase64fromText(self.pem_text)
         asn1Object, rest = der_decode(substrate,
             asn1Spec=self.asn1Spec,
+            openTypes=openTypesMap,
             decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate
 
         for attr in asn1Object:
-            assert attr['type'] in rfc5280.certificateAttributesMap
+            assert attr['type'] in openTypesMap.keys()
 
             if attr['type'] == rfc2985.pkcs_9_at_userPKCS12:
                 assert attr['values'][0]['version'] == univ.Integer(3)
@@ -252,7 +255,7 @@ HktMK+isIjxOTk4yJTOOAgIH0A==
                     for sb in sc:
                         if sb['bagId'] in rfc7292.pkcs12BagTypeMap:
                             for bagattr in sb['bagAttributes']:
-                                if bagattr['attrType'] in rfc5280.certificateAttributesMap:
+                                if bagattr['attrType'] in openTypesMap:
 
                                     if bagattr['attrType'] == rfc2985.pkcs_9_at_friendlyName:
                                         assert bagattr['attrValues'][0] == "3f71af65-1687-444a-9f46-c8be194c3e8e"
@@ -268,7 +271,7 @@ HktMK+isIjxOTk4yJTOOAgIH0A==
                     assert si['version'] == 1
 
                     for siattr in si['signedAttrs']:
-                        if siattr['attrType'] in rfc5280.certificateAttributesMap:
+                        if siattr['attrType'] in openTypesMap:
  
                             if siattr['attrType'] == rfc2985.pkcs_9_at_contentType:
                                 assert siattr['attrValues'][0] == rfc5652.id_data
@@ -281,8 +284,7 @@ HktMK+isIjxOTk4yJTOOAgIH0A==
 
                 for choices in attr['values'][0]['content']['certificates']:
                     for rdn in choices[0]['tbsCertificate']['subject']['rdnSequence']:
-                        if rdn[0]['type'] in rfc5280.certificateAttributesMap:
-
+                        if rdn[0]['type'] in openTypesMap:
                             if rdn[0]['type'] == rfc2985.pkcs_9_at_emailAddress:
                                 assert rdn[0]['value'] == 'alice@example.com'
 

--- a/tests/test_rfc2986.py
+++ b/tests/test_rfc2986.py
@@ -6,8 +6,8 @@
 #
 import sys
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decode
+from pyasn1.codec.der.encoder import encode as der_encode
 
 from pyasn1.type import char
 from pyasn1.type import univ
@@ -50,28 +50,28 @@ fi6h7i9VVAZpslaKFfkNg12gLbbsCB1q36l5VXjHY/qe0FIUa9ogRrOi
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
 
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
 
     def testOpenTypes(self):
-        algorithmIdentifierMapUpdate = {
+        openTypesMap = {
             univ.ObjectIdentifier('1.2.840.113549.1.1.1'): univ.Null(""),
             univ.ObjectIdentifier('1.2.840.113549.1.1.5'): univ.Null(""),
             univ.ObjectIdentifier('1.2.840.113549.1.1.11'): univ.Null(""),
         }
 
-        rfc5280.algorithmIdentifierMap.update(algorithmIdentifierMapUpdate)
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decoder.decode(substrate,
+        asn1Object, rest = der_decode(substrate,
             asn1Spec=rfc2986.CertificationRequest(),
+            openTypes=openTypesMap,
             decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
 
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
 
         for rdn in asn1Object['certificationRequestInfo']['subject']['rdnSequence']:
             for atv in rdn:

--- a/tests/test_rfc3274.py
+++ b/tests/test_rfc3274.py
@@ -57,11 +57,9 @@ XQ7u2qbaKFtZ7V96NH8ApkUFkg==
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.compressed_data_pem_text)
-
-        rfc5652.cmsContentTypesMap.update(rfc3274.cmsContentTypesMapUpdate)
         asn1Object, rest = der_decode(substrate, 
-                                      asn1Spec=self.asn1Spec,
-                                      decodeOpenTypes=True)
+            asn1Spec=self.asn1Spec,
+            decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate

--- a/tests/test_rfc3770.py
+++ b/tests/test_rfc3770.py
@@ -54,10 +54,9 @@ DAlVlhox680Jxy5J8Pkx
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.cert_pem_text)
-        rfc5280.algorithmIdentifierMap.update(rfc5480.algorithmIdentifierMapUpdate)
         asn1Object, rest = der_decode(substrate,
-                                      asn1Spec=self.asn1Spec,
-                                      decodeOpenTypes=True)
+            asn1Spec=self.asn1Spec,
+            decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate

--- a/tests/test_rfc3779.py
+++ b/tests/test_rfc3779.py
@@ -76,7 +76,6 @@ V+vo2L72yerdbsP9xjqvhZrLKfsLZjYK4SdYYthi
 
     def testExtensionsMap(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        rfc5280.certificateExtensionsMap.update(rfc3779.certificateExtensionsMapUpdate)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
         assert not rest
         assert asn1Object.prettyPrint()

--- a/tests/test_rfc4073.py
+++ b/tests/test_rfc4073.py
@@ -83,8 +83,6 @@ buWO3egPDL8Kf7tBhzjIKLw=
     
             return asn1Object
 
-        rfc5652.cmsAttributesMap.update(rfc2634.ESSAttributeMap)
-        rfc5652.cmsContentTypesMap.update(rfc4073.cmsContentTypesMapUpdate)
         layers = rfc5652.cmsContentTypesMap
 
         getNextLayer = {
@@ -120,14 +118,10 @@ buWO3egPDL8Kf7tBhzjIKLw=
                 this_layer = getNextLayer[this_layer](asn1Object)
 
     def testOpenTypes(self):
-
         substrate = pem.readBase64fromText(self.pem_text)
-
-        rfc5652.cmsAttributesMap.update(rfc2634.ESSAttributeMap)
-        rfc5652.cmsContentTypesMap.update(rfc4073.cmsContentTypesMapUpdate)
         asn1Object, rest = der_decode(substrate,
-                                      asn1Spec=rfc5652.ContentInfo(),
-                                      decodeOpenTypes=True)
+            asn1Spec=rfc5652.ContentInfo(),
+            decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate

--- a/tests/test_rfc4108.py
+++ b/tests/test_rfc4108.py
@@ -74,7 +74,7 @@ dsnhVtIdkPtfJIvcYteYJg==
             attribute_list.append(attr['attrType'])
             if attr['attrType'] == rfc4108.id_aa_targetHardwareIDs:
                 av, rest = der_decode(attr['attrValues'][0],
-                                      asn1Spec=rfc4108.TargetHardwareIdentifiers())
+                    asn1Spec=rfc4108.TargetHardwareIdentifiers())
                 assert len(av) == 2
                 for oid in av:
                     assert '1.3.6.1.4.1.221121.1.1.' in oid.prettyPrint()
@@ -86,12 +86,9 @@ dsnhVtIdkPtfJIvcYteYJg==
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.pem_text)
-
-        rfc5652.cmsContentTypesMap.update(rfc4108.cmsContentTypesMapUpdate)
-        rfc5652.cmsAttributesMap.update(rfc4108.cmsAttributesMapUpdate)
         asn1Object, rest = der_decode(substrate,
-                                      asn1Spec=self.asn1Spec,
-                                      decodeOpenTypes=True)
+            asn1Spec=self.asn1Spec,
+            decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate

--- a/tests/test_rfc5035.py
+++ b/tests/test_rfc5035.py
@@ -76,8 +76,8 @@ T9yMtRLN5ZDU14y+Phzq9NKpSw/x5KyXoUKjCMc3Ru6dIW+CgcRQees+dhnvuD5U
             sat = sa['attrType']
             sav0 = sa['attrValues'][0]
 
-            if sat in rfc5035.ESSAttributeMap.keys():
-                sav, rest = der_decode(sav0, asn1Spec=rfc5035.ESSAttributeMap[sat])
+            if sat in rfc5652.cmsAttributesMap.keys():
+                sav, rest = der_decode(sav0, asn1Spec=rfc5652.cmsAttributesMap[sat])
                 assert not rest
                 assert sav.prettyPrint()
                 assert der_encode(sav) == sav0
@@ -138,16 +138,14 @@ vFIgX7eIkd8=
             sat = sa['attrType']
             sav0 = sa['attrValues'][0]
 
-            if sat in rfc5035.ESSAttributeMap.keys():
-                sav, rest = der_decode(sav0, asn1Spec=rfc5035.ESSAttributeMap[sat])
+            if sat in rfc5652.cmsAttributesMap.keys():
+                sav, rest = der_decode(sav0, asn1Spec=rfc5652.cmsAttributesMap[sat])
                 assert not rest
                 assert sav.prettyPrint()
                 assert der_encode(sav) == sav0
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.signed_receipt_pem_text)
-        rfc5652.cmsContentTypesMap.update(rfc5035.cmsContentTypesMapUpdate)
-        rfc5652.cmsAttributesMap.update(rfc5035.ESSAttributeMap)
         asn1Object, rest = der_decode(substrate,
             asn1Spec=self.asn1Spec, decodeOpenTypes=True)
         assert not rest
@@ -171,7 +169,7 @@ vFIgX7eIkd8=
         # automatically decode it 
         receipt, rest = der_decode(sd['encapContentInfo']['eContent'],
             asn1Spec=rfc5652.cmsContentTypesMap[sd['encapContentInfo']['eContentType']])
-        assert receipt['version'] == rfc5035.ESSVersion().subtype(value='v1')
+        assert receipt['version'] == 1
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5083.py
+++ b/tests/test_rfc5083.py
@@ -8,8 +8,8 @@
 
 import sys
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decode
+from pyasn1.codec.der.encoder import encode as der_encode
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5652
@@ -43,10 +43,10 @@ ur76ztut3sr4iIANmvLRbyFUf87+2bPvLQQMoOWSXMGE4BckY8RM
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
 
 
 class AuthEnvelopedDataOpenTypesTestCase(unittest.TestCase):
@@ -73,19 +73,17 @@ IDAeDBFXYXRzb24sIGNvbWUgaGVyZQYJKoZIhvcNAQcB
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        rfc5652.cmsAttributesMap.update(rfc5035.ESSAttributeMap)
-        rfc5652.cmsContentTypesMap.update(rfc5083.cmsContentTypesMapUpdate)
-        asn1Object, rest = der_decoder.decode(substrate,
-                                              asn1Spec=self.asn1Spec,
-                                              decodeOpenTypes=True)
+        asn1Object, rest = der_decode(substrate,
+            asn1Spec=self.asn1Spec,
+            decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
 
         assert asn1Object['contentType'] in rfc5652.cmsContentTypesMap
         assert asn1Object['contentType'] == rfc5083.id_ct_authEnvelopedData
         authenv = asn1Object['content']
-        assert authenv['version'] == rfc5652.CMSVersion().subtype(value='v0')
+        assert authenv['version'] == 0
 
         for attr in authenv['unauthAttrs']:
             assert attr['attrType'] in rfc5652.cmsAttributesMap

--- a/tests/test_rfc5084.py
+++ b/tests/test_rfc5084.py
@@ -8,11 +8,13 @@
 
 import sys
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decode
+from pyasn1.codec.der.encoder import encode as der_encode
 
 from pyasn1_modules import pem
+from pyasn1_modules import rfc5083
 from pyasn1_modules import rfc5084
+from pyasn1_modules import rfc5652
 
 try:
     import unittest2 as unittest
@@ -28,10 +30,10 @@ class CCMParametersTestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.ccm_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
 
 
 class GCMParametersTestCase(unittest.TestCase):
@@ -42,10 +44,74 @@ class GCMParametersTestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.gcm_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
+
+
+class GCMOpenTypesTestCase(unittest.TestCase):
+    rfc8591_pem_pext = """\
+MIIHkAYLKoZIhvcNAQkQARegggd/MIIHewIBADGCAk8wggJLAgEAMDMwJjEUMBIGA1UECgwL
+ZXhhbXBsZS5jb20xDjAMBgNVBAMMBUFsaWNlAgkAg/ULtwvVxA4wDQYJKoZIhvcNAQEBBQAE
+ggIAdZphtN3x8a8kZoAFY15HYRD6JyPBueRUhLbTPoOH3pZ9xeDK+zVXGlahl1y1UOe+McEx
+2oD7cxAkhFuruNZMrCYEBCTZMwVhyEOZlBXdZEs8rZUHL3FFE5PJnygsSIO9DMxd1UuTFGTg
+Cm5V5ZLFGmjeEGJRbsfTyo52S7iseJqIN3dl743DbApu0+yuUoXKxqKdUFlEVxmhvc+Qbg/z
+fiwu8PTsYiUQDMBi4cdIlju8iLjj389xQHNyndXHWD51is89GG8vpBe+IsN8mnbGtCcpqtJ/
+c65ErJhHTR7rSJSMEqQD0LPOCKIY1q9FaSSJfMXJZk9t/rPxgUEVjfw7hAkKpgOAqoZRN+Fp
+nFyBl0FnnXo8kLp55tfVyNibtUpmdCPkOwt9b3jAtKtnvDQ2YqY1/llfEUnFOVDKwuC6MYwi
+fm92qNlAQA/T0+ocjs6gA9zOLx+wD1zqM13hMD/L+T2OHL/WgvGb62JLrNHXuPWA8RShO4kI
+lPtARKXap2S3+MX/kpSUUrNa65Y5uK1jwFFclczG+CPCIBBn6iJiQT/vOX1I97YUP4Qq6OGk
+jK064Bq6o8+e5+NmIOBcygYRv6wA7vGkmPLSWbnw99qD728bBh84fC3EjItdusqGIwjzL0eS
+UWXJ5eu0Z3mYhJGN1pe0R/TEB5ibiJsMLpWAr3gwggUPBgkqhkiG9w0BBwEwHgYJYIZIAWUD
+BAEGMBEEDE2HVyIurFKUEX8MEgIBEICCBOD+L7PeC/BpmMOb9KlS+r+LD+49fi6FGBrs8aie
+Gi7ezZQEiFYS38aYQzTYYCt3SbJQTkX1fDsGZiaw/HRiNh7sJnxWATm+XNKGoq+Wls9RhSJ4
+5Sw4GMqwpoxZjeT84UozOITk3l3fV+3XiGcCejHkp8DAKZFExd5rrjlpnnAOBX6w8NrXO4s2
+n0LrMhtBU4eB2YKhGgs5Q6wQyXtU7rc7OOwTGvxWEONzSHJ01pyvqVQZAohsZPaWLULrM/kE
+GkrhG4jcaVjVPfULi7Uqo14imYhdCq5Ba4bwqI0Ot6mB27KD6LlOnVC/YmXCNIoYoWmqy1o3
+pSm9ovnLEO/dzxQjEJXYeWRje9M/sTxotM/5oZBpYMHqIwHTJbehXFgp8+oDjyTfayMYA3fT
+cTH3XbGPQfnYW2U9+ka/JhcSYybM8cuDNFd1I1LIQXoJRITXtkvPUbJqm+s6DtS5yvG9I8aQ
+xlT365zphS4vbQaO74ujO8bE3dynrvTTV0c318TcHpN3DY9PIt6mHXMIPDLEA4wes90zg6ia
+h5XiQcLtfLaAdYwEEGlImGD8n0kOhSNgclSLMklpj5mVOs8exli3qoXlVMRJcBptSwOe0QPc
+RY30spywS4zt1UDIQ0jaecGGVtUYj586nkubhAxwZkuQKWxgt6yYTpGNSKCdvd+ygfyGJRDb
+Wdn6nck/EPnG1773KTHRhMrXrBPBpSlfyJ/ju3644CCFqCjFoTh4bmB63k9ejUEVkJIJuoeK
+eTBaUxbCIinkK4htBkgchHP51RJp4q9jQbziD3aOhg13hO1GFQ4E/1DNIJxbEnURNp/ga8Sq
+mnLY8f5Pzwhm1mSzZf+obowbQ+epISrswWyjUKKO+uJfrAVN2TS/5+X6T3U6pBWWjH6+xDng
+rAJwtIdKBo0iSEwJ2eir4X8TcrSy9l8RSOiTPtqS5dF3RWSWOzkcO72fHCf/42+DLgUVX8Oe
+5mUvp7QYiXXsXGezLJ8hPIrGuOEypafDv3TwFkBc2MIB0QUhk+GG1ENY3jiNcyEbovF5Lzz+
+ubvechHSb1arBuEczJzN4riM2Dc3c+r8N/2Ft6eivK7HUuYX1uAcArhunZpA8yBGLF1m+DUX
+FtzWAUvfMKYPdfwGMckghF7YwLrTXd8ZhPIkHNO1KdwQKIRfgIlUPfTxRB7eNrG/Ma9a/Iwr
+cI1QtkXU59uIZIw+7+FHZRWPsOjTu1Pdy+JtcSTG4dmS+DIwqpUzdu6MaBCVaOhXHwybvaSP
+TfMG/nR/NxF1FI8xgydnzXZs8HtFDL9iytKnvXHx+IIz8Rahp/PK8S80vPQNIeef/JgnIhto
+sID/A614LW1tB4cWdveYlD5U8T/XXInAtCY78Q9WJD+ecu87OJmlOdmjrFvitpQAo8+NGWxc
+7Wl7LtgDuYel7oXFCVtI2npbA7R+K5/kzUvDCY6GTgzn1Gfamc1/Op6Ue17qd/emvhbIx+ng
+3swf8TJVnCNDIXucKVA4boXSlCEhCGzfoZZYGVvm1/hrypiBtpUIKWTxLnz4AQJdZ5LGiCQJ
+QU1wMyHsg6vWmNaJVhGHE6D/EnKsvJptFIkAx0wWkh35s48p7EbU8QBg//5eNru6yvLRutfd
+BX7T4w681pCD+dOiom75C3UdahrfoFkNsZ2hB88+qNsEEPb/xuGu8ZzSPZhakhl2NS0=
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc5652.ContentInfo()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.rfc8591_pem_pext)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encode(asn1Object) == substrate
+
+        assert asn1Object['contentType'] == rfc5083.id_ct_authEnvelopedData
+        aed, rest = der_decode(asn1Object['content'],
+            asn1Spec=rfc5083.AuthEnvelopedData(),
+            decodeOpenTypes=True)
+        assert not rest
+        assert aed.prettyPrint()
+        assert der_encode(aed) == asn1Object['content']
+
+        assert aed['version'] == 0
+        cea = aed['authEncryptedContentInfo']['contentEncryptionAlgorithm']
+        assert cea['algorithm'] == rfc5084.id_aes128_GCM
+        assert cea['parameters']['aes-ICVlen'] == 16
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5480.py
+++ b/tests/test_rfc5480.py
@@ -8,13 +8,12 @@
 
 import sys
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decode
+from pyasn1.codec.der.encoder import encode as der_encode
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5280
 from pyasn1_modules import rfc5480
-from pyasn1_modules import rfc4055
 
 try:
     import unittest2 as unittest
@@ -51,27 +50,24 @@ Ea8/B6hPatJ0ES8q/HO3X8IVQwVs1n3aAr0im0/T+Xc=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.digicert_ec_cert_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+        assert der_encode(asn1Object) == substrate
 
         algid = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
         assert algid['algorithm'] == rfc5480.id_ecPublicKey
-        param, rest = der_decoder.decode(algid['parameters'], asn1Spec=rfc5480.ECParameters())
+        param, rest = der_decode(algid['parameters'], asn1Spec=rfc5480.ECParameters())
         assert param.prettyPrint()
         assert param['namedCurve'] == rfc5480.secp384r1
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.digicert_ec_cert_pem_text)
-        rfc5280.algorithmIdentifierMap.update(rfc5480.algorithmIdentifierMapUpdate)
-        asn1Object, rest = der_decoder.decode(substrate,
-                                              asn1Spec=self.asn1Spec,
-                                              decodeOpenTypes=True)
+        asn1Object, rest = der_decode(substrate,
+            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
     
         spki_alg = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
         assert spki_alg['algorithm'] == rfc5480.id_ecPublicKey

--- a/tests/test_rfc5940.py
+++ b/tests/test_rfc5940.py
@@ -81,7 +81,7 @@ ttTMEpl2prH8bbwo1g==
 
         assert asn1Object['contentType'] == rfc5652.id_signedData
         sd, rest = der_decode(asn1Object['content'],
-                              asn1Spec=rfc5652.SignedData())
+            asn1Spec=rfc5652.SignedData())
         assert sd.prettyPrint()
 
         assert sd['encapContentInfo']['eContentType'] == rfc5652.id_data
@@ -92,18 +92,16 @@ ttTMEpl2prH8bbwo1g==
         assert sd['crls'][1]['other']['otherRevInfoFormat'] == ocspr_oid
 
         ocspr, rest = der_decode(sd['crls'][1]['other']['otherRevInfo'],
-                                 asn1Spec=rfc5940.OCSPResponse())
+            asn1Spec=rfc5940.OCSPResponse())
         assert ocspr.prettyPrint()
         success = rfc2560.OCSPResponseStatus(value='successful')
         assert ocspr['responseStatus'] == success
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.pem_text)
-
-        rfc5652.otherRevInfoFormatMap.update(rfc5940.otherRevInfoFormatMapUpdate)
         asn1Object, rest = der_decode(substrate,
-                                      asn1Spec=self.asn1Spec,
-                                      decodeOpenTypes=True)
+            asn1Spec=self.asn1Spec,
+            decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate

--- a/tests/test_rfc5958.py
+++ b/tests/test_rfc5958.py
@@ -8,8 +8,8 @@
 
 import sys
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decode
+from pyasn1.codec.der.encoder import encode as der_encode
 
 from pyasn1.type import univ
 
@@ -36,7 +36,7 @@ Z9w7lshQhqowtrbLDFw4rXAxZuE=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.priv_key_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
         assert not rest
         assert asn1Object.prettyPrint()
         assert asn1Object['privateKeyAlgorithm']['algorithm'] == rfc8410.id_Ed25519
@@ -44,7 +44,7 @@ Z9w7lshQhqowtrbLDFw4rXAxZuE=
         assert asn1Object['privateKey'].prettyPrint()[0:10] == "0x0420d4ee"
         assert asn1Object['publicKey'].isValue
         assert asn1Object['publicKey'].prettyPrint()[0:10] == "1164575857"
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
 
 
 class PrivateKeyOpenTypesTestCase(unittest.TestCase):
@@ -59,13 +59,11 @@ YWlyc4EhABm/RAlphM3+hUG6wWfcO5bIUIaqMLa2ywxcOK1wMWbh
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.asymmetric_key_pkg_pem_text)
-        rfc5652.cmsContentTypesMap.update(rfc5958.cmsContentTypesMapUpdate)
-        asn1Object, rest = der_decoder.decode(substrate,
-                                              asn1Spec=self.asn1Spec,
-                                              decodeOpenTypes=True)
+        asn1Object, rest = der_decode(substrate,
+            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        assert der_encode(asn1Object) == substrate
 
         assert rfc5958.id_ct_KP_aKeyPackage in rfc5652.cmsContentTypesMap.keys()
         oneKey = asn1Object['content'][0]

--- a/tests/test_rfc6019.py
+++ b/tests/test_rfc6019.py
@@ -43,8 +43,6 @@ class BinarySigningTimeTestCase(unittest.TestCase):
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        
-        rfc5652.cmsAttributesMap.update(rfc6019.cmsAttributesMapUpdate)
         asn1Object, rest = der_decode(substrate,
                                       asn1Spec=self.asn1Spec,
                                       decodeOpenTypes=True)

--- a/tests/test_rfc7030.py
+++ b/tests/test_rfc7030.py
@@ -60,12 +60,15 @@ BgcrBgEBAQEWBggqhkjOPQQDAw==
                 assert attr_or_oid['attribute']['attrType'] in self.the_attrTypes
 
     def testOpenTypes(self):
+        openTypesMap = { }
+        openTypesMap.update(rfc5652.cmsAttributesMap)
         for at in self.the_attrTypes:
-            rfc5652.cmsAttributesMap.update({ at: univ.ObjectIdentifier(), })
-   
+            openTypesMap.update({ at: univ.ObjectIdentifier(), })
+
         substrate = pem.readBase64fromText(self.pem_text)
         asn1Object, rest = der_decode(substrate,
             asn1Spec=self.asn1Spec,
+            openTypes=openTypesMap,
             decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
@@ -80,6 +83,7 @@ BgcrBgEBAQEWBggqhkjOPQQDAw==
             
                 if attr_or_oid['attribute']['attrType'] == self.the_attrTypes[1]:
                     assert valString == self.the_attrVals[1]
+
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
 

--- a/tests/test_rfc7894.py
+++ b/tests/test_rfc7894.py
@@ -1,0 +1,86 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2019, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+
+import sys
+
+from pyasn1.codec.der.decoder import decode as der_decode
+from pyasn1.codec.der.encoder import encode as der_encode
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc6402
+from pyasn1_modules import rfc7894
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+class AlternativeChallengePasswordTestCase(unittest.TestCase):
+    otp_pem_text = """\
+MIICsjCCAZwCAQAwJDELMAkGA1UEBhMCVVMxFTATBgNVBAMTDDRUUzJWMk5MWEE2
+WjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKmF0oUj5+1rBB+pUO8X
+7FPxer+1BhWOa54RTSucJmBaLx0H95qNaBCcctNDl1kcmIro/a0zMcEvj5Do29vQ
+lStJdTeJ/B3X4qzOGShupxJcAhCreRZjN6Yz3T9z0zJ8OPnRvJOzcSiIzlubc9lK
+Cpq4U0UsCLLfymOgL9NH4lZi96J+PFuJr0J+rTY38076U2jcPqNq5/L/d6NV9Sz2
+IVOvCK1kqP/nElJVibIQZvj9YESLUKyVAfTNxLj3+IpioOOv2dT3kB9wdi4plAVi
+UFEUvED1okRrI29+LdPV1UXglOCksyJIIw+DgDtutDE5Co6QkTNURFEdKIV9Sg13
+zEECAwEAAaBLMBkGCyqGSIb3DQEJEAI4MQoTCDkwNTAzODQ2MC4GCSqGSIb3DQEJ
+DjEhMB8wHQYDVR0OBBYEFBj12LVowM16Ed0D+AmoElKNYP/kMAsGCSqGSIb3DQEB
+CwOCAQEAZZdDWKejs3UVfgZI3R9cMWGijmscVeZrjwFVkn7MI9pEDZ2aS1QaRYjY
+1cu9j3i+LQp9LWPIW/ztYk11e/OcZp3fo8pZ+MT66n7YTWfDXNkqqA5xmI84DMEx
+/cqenyzOBZWqpZGx7eyM9BtnrdeJ0r2qSc7LYU25FbIQFJJf8IvgMAXWMs50fvs2
+Gzns447x952se2ReQ3vYhXdHvYYcgAZfSJZvK+nCmhzzqowv5p15Y5S+IHpBSXTO
+a1qhNW4cjdicQZUeQ2R5kiuwZ+8vHaq9jKxAEk0hBeqG6RQaxvNOBQhHtTLNGw/C
+NmaF8Y2Sl/MgvC5tjs0Ck0/r3lsoLQ==
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc6402.CertificationRequest()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.otp_pem_text)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encode(asn1Object) == substrate
+
+        assert asn1Object['certificationRequestInfo']['version'] == 0
+
+        for attr in asn1Object['certificationRequestInfo']['attributes']:
+            assert attr['attrType'] in rfc6402.cmcControlAttributesMap.keys()
+            av, rest = der_decode(attr['attrValues'][0],
+                rfc6402.cmcControlAttributesMap[attr['attrType']])
+            assert not rest
+            assert der_encode(av) == attr['attrValues'][0]
+
+            if attr['attrType'] == rfc7894.id_aa_otpChallenge:
+                assert av['printableString'] == '90503846'
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.otp_pem_text)
+        asn1Object, rest = der_decode(substrate,
+            asn1Spec=self.asn1Spec,
+            decodeOpenTypes=True)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encode(asn1Object) == substrate
+
+        for attr in asn1Object['certificationRequestInfo']['attributes']:
+            assert attr['attrType'] in rfc6402.cmcControlAttributesMap.keys()
+            if attr['attrType'] == rfc7894.id_aa_otpChallenge:
+                assert attr['attrValues'][0]['printableString'] == '90503846'
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    import sys
+
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())

--- a/tests/test_rfc7906.py
+++ b/tests/test_rfc7906.py
@@ -145,10 +145,15 @@ toMsV8fLBpBjA5YGQvd3TAcSw1lNbWpArL+hje1dzQ7pxslnkklv3CTxAjBuVebz
                 assert av == univ.OctetString(hexValue='7906')
 
     def testOpenTypes(self):
+        openTypesMap = { }
+        openTypesMap.update(rfc5280.certificateAttributesMap)
+        openTypesMap.update(rfc5652.cmsAttributesMap)
+
         substrate = pem.readBase64fromText(self.attr_set_pem_text)
-        rfc5280.certificateAttributesMap.update(rfc5652.cmsAttributesMap)
-        asn1Object, rest = der_decode (substrate,
-            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        asn1Object, rest = der_decode(substrate,
+            asn1Spec=self.asn1Spec,
+            openTypes=openTypesMap,
+            decodeOpenTypes=True)
         assert not rest
         assert asn1Object.prettyPrint()
         assert der_encode(asn1Object) == substrate

--- a/tests/test_rfc8520.py
+++ b/tests/test_rfc8520.py
@@ -84,7 +84,6 @@ izaUuU1EEwgOMELjeFL62Ssvq8X+x6hZFCLygI7GNeitlblNhCXhFFurqMs=
 
     def testExtensionsMap(self):
         substrate = pem.readBase64fromText(self.mud_cert_pem_text)
-        rfc5280.certificateExtensionsMap.update(rfc8520.certificateExtensionsMapUpdate)
         asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
         assert not rest
         assert asn1Object.prettyPrint()


### PR DESCRIPTION
Added module and test to support RFC7894; this replaces the previous PR.

Updated the handling of maps for use with openType so that just doing an import of the modules is enough in most situations; updates to RFC 2634, RFC 3274, RFC 3779, RFC 4073, RFC 4108, RFC 5035, RFC 5083, RFC 5084, RFC 5480, RFC 5940, RFC 5958, RFC 6019, and RFC 8520.