### PR TITLE
Update map used for OpenTypes in RFC 5958

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,6 +26,8 @@ Revision 0.2.7, released XX-09-2019
   an import of the modules is enough in most situations; updates to
   RFC 2634, RFC 3274, RFC 3779, RFC 4073, RFC 4108, RFC 5035, RFC 5083,
   RFC 5084, RFC 5480, RFC 5940, RFC 5958, RFC 6019, and RFC 8520
+- Updated the handling of attribute maps for use with openType in
+  RFC 5958 to use the rfc5652.cmsAttributesMap
 - Added RFC5990 providing RSA-KEM Key Transport Algorithm in the CMS
 - Fixed malformed `rfc4210.RevRepContent` data structure layout
 - Added RFC5934 providing Trust Anchor Management Protocol (TAMP)

--- a/pyasn1_modules/rfc5958.py
+++ b/pyasn1_modules/rfc5958.py
@@ -50,7 +50,7 @@ class PrivateKey(univ.OctetString):
 
 
 class Attributes(univ.SetOf):
-    componentType = rfc5280.Attribute()
+    componentType = rfc5652.Attribute()
 
 
 class PublicKey(univ.BitString):

--- a/tests/test_rfc5958.py
+++ b/tests/test_rfc5958.py
@@ -69,7 +69,7 @@ YWlyc4EhABm/RAlphM3+hUG6wWfcO5bIUIaqMLa2ywxcOK1wMWbh
         oneKey = asn1Object['content'][0]
         assert oneKey['privateKeyAlgorithm']['algorithm'] == rfc8410.id_Ed25519
         pkcs_9_at_friendlyName = univ.ObjectIdentifier('1.2.840.113549.1.9.9.20')
-        assert oneKey['attributes'][0]['type'] == pkcs_9_at_friendlyName
+        assert oneKey['attributes'][0]['attrType'] == pkcs_9_at_friendlyName
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
Updated the handling of attribute maps for use with openType in RFC 5958 to use the rfc5652.cmsAttributesMap