### PR TITLE
Add support for RFC 6960

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Revision 0.2.8, released XX-XX-2019
 - Added RFC7633 providing TLS Features Certificate Extension
 - Added RFC7229 providing OIDs for Test Certificate Policies
 - Added tests for RFC3280, RFC3281, RFC3852, and RFC4211
+- Added RFC6960 providing Online Certificate Status Protocol (OCSP)
 
 Revision 0.2.7, released 09-10-2019
 -----------------------------------

--- a/pyasn1_modules/rfc6960.py
+++ b/pyasn1_modules/rfc6960.py
@@ -1,0 +1,223 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2019, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Online Certificate Status Protocol (OCSP)
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc6960.txt
+#
+
+from pyasn1.type import univ, char, namedtype, namedval, tag, constraint, useful
+
+from pyasn1_modules import rfc2560
+from pyasn1_modules import rfc5280
+
+MAX = float('inf')
+
+
+# Imports from RFC 5280
+
+AlgorithmIdentifier = rfc5280.AlgorithmIdentifier
+AuthorityInfoAccessSyntax = rfc5280.AuthorityInfoAccessSyntax
+Certificate = rfc5280.Certificate
+CertificateSerialNumber = rfc5280.CertificateSerialNumber
+CRLReason = rfc5280.CRLReason
+Extensions = rfc5280.Extensions
+GeneralName = rfc5280.GeneralName
+Name = rfc5280.Name
+
+id_kp = rfc5280.id_kp
+
+id_ad_ocsp = rfc5280.id_ad_ocsp
+
+
+# Imports from the original OCSP module in RFC 2560
+
+AcceptableResponses = rfc2560.AcceptableResponses
+ArchiveCutoff = rfc2560.ArchiveCutoff
+CertStatus = rfc2560.CertStatus
+KeyHash = rfc2560.KeyHash
+OCSPResponse = rfc2560.OCSPResponse
+OCSPResponseStatus = rfc2560.OCSPResponseStatus
+ResponseBytes = rfc2560.ResponseBytes
+RevokedInfo = rfc2560.RevokedInfo
+UnknownInfo = rfc2560.UnknownInfo
+Version = rfc2560.Version
+
+id_kp_OCSPSigning = rfc2560.id_kp_OCSPSigning
+
+id_pkix_ocsp = rfc2560.id_pkix_ocsp
+id_pkix_ocsp_archive_cutoff = rfc2560.id_pkix_ocsp_archive_cutoff
+id_pkix_ocsp_basic = rfc2560.id_pkix_ocsp_basic
+id_pkix_ocsp_crl = rfc2560.id_pkix_ocsp_crl
+id_pkix_ocsp_nocheck = rfc2560.id_pkix_ocsp_nocheck
+id_pkix_ocsp_nonce = rfc2560.id_pkix_ocsp_nonce
+id_pkix_ocsp_response = rfc2560.id_pkix_ocsp_response
+id_pkix_ocsp_service_locator = rfc2560.id_pkix_ocsp_service_locator
+
+
+# Additional object identifiers
+
+id_pkix_ocsp_pref_sig_algs = id_pkix_ocsp + (8, )
+id_pkix_ocsp_extended_revoke = id_pkix_ocsp + (9, )
+
+
+# Updated structures (mostly to improve openTypes support)
+
+class CertID(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('hashAlgorithm', AlgorithmIdentifier()),
+        namedtype.NamedType('issuerNameHash', univ.OctetString()),
+        namedtype.NamedType('issuerKeyHash', univ.OctetString()),
+        namedtype.NamedType('serialNumber', CertificateSerialNumber())
+    )
+
+
+class SingleResponse(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('certID', CertID()),
+        namedtype.NamedType('certStatus', CertStatus()),
+        namedtype.NamedType('thisUpdate', useful.GeneralizedTime()),
+        namedtype.OptionalNamedType('nextUpdate', useful.GeneralizedTime().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+        namedtype.OptionalNamedType('singleExtensions', Extensions().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1)))
+    )
+
+
+class ResponderID(univ.Choice):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('byName', Name().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
+        namedtype.NamedType('byKey', KeyHash().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)))
+    )
+
+
+class ResponseData(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.DefaultedNamedType('version', Version('v1').subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+        namedtype.NamedType('responderID', ResponderID()),
+        namedtype.NamedType('producedAt', useful.GeneralizedTime()),
+        namedtype.NamedType('responses', univ.SequenceOf(
+            componentType=SingleResponse())),
+        namedtype.OptionalNamedType('responseExtensions', Extensions().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1)))
+    )
+
+
+class BasicOCSPResponse(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('tbsResponseData', ResponseData()),
+        namedtype.NamedType('signatureAlgorithm', AlgorithmIdentifier()),
+        namedtype.NamedType('signature', univ.BitString()),
+        namedtype.OptionalNamedType('certs', univ.SequenceOf(
+            componentType=Certificate()).subtype(explicitTag=tag.Tag(
+                tag.tagClassContext, tag.tagFormatSimple, 0)))
+    )
+
+
+class Request(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('reqCert', CertID()),
+        namedtype.OptionalNamedType('singleRequestExtensions', Extensions().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
+    )
+
+
+class Signature(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('signatureAlgorithm', AlgorithmIdentifier()),
+        namedtype.NamedType('signature', univ.BitString()),
+        namedtype.OptionalNamedType('certs', univ.SequenceOf(
+            componentType=Certificate()).subtype(explicitTag=tag.Tag(
+                tag.tagClassContext, tag.tagFormatSimple, 0)))
+    )
+
+
+class TBSRequest(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.DefaultedNamedType('version', Version('v1').subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+        namedtype.OptionalNamedType('requestorName', GeneralName().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
+        namedtype.NamedType('requestList', univ.SequenceOf(
+            componentType=Request())),
+        namedtype.OptionalNamedType('requestExtensions', Extensions().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)))
+    )
+
+
+class OCSPRequest(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('tbsRequest', TBSRequest()),
+        namedtype.OptionalNamedType('optionalSignature', Signature().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0)))
+    )
+
+
+# Previously omitted structure
+
+class ServiceLocator(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('issuer', Name()),
+        namedtype.NamedType('locator', AuthorityInfoAccessSyntax())
+    )
+
+
+# Additional structures
+
+class CrlID(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.OptionalNamedType('crlUrl', char.IA5String().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
+        namedtype.OptionalNamedType('crlNum', univ.Integer().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
+        namedtype.OptionalNamedType('crlTime', useful.GeneralizedTime().subtype(
+            explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 2)))
+    )
+
+
+class PreferredSignatureAlgorithm(univ.Sequence):
+    componentType = namedtype.NamedTypes(
+        namedtype.NamedType('sigIdentifier', AlgorithmIdentifier()),
+        namedtype.OptionalNamedType('certIdentifier', AlgorithmIdentifier())
+    )
+
+
+class PreferredSignatureAlgorithms(univ.SequenceOf):
+    componentType = PreferredSignatureAlgorithm()
+
+
+
+# Response Type OID to Response Map
+
+ocspResponseMap = {
+    id_pkix_ocsp_basic: BasicOCSPResponse(),
+}
+
+
+# Map of Extension OIDs to Extensions added to the ones
+# that are in rfc5280.py
+
+_certificateExtensionsMapUpdate = {
+    # Certificate Extension
+    id_pkix_ocsp_nocheck: univ.Null(""),
+    # OCSP Request Extensions
+    id_pkix_ocsp_nonce: univ.OctetString(),
+    id_pkix_ocsp_response: AcceptableResponses(),
+    id_pkix_ocsp_service_locator: ServiceLocator(),
+    id_pkix_ocsp_pref_sig_algs: PreferredSignatureAlgorithms(),
+    # OCSP Response Extensions
+    id_pkix_ocsp_crl: CrlID(),
+    id_pkix_ocsp_archive_cutoff: ArchiveCutoff(),
+    id_pkix_ocsp_extended_revoke: univ.Null(""),
+}
+
+rfc5280.certificateExtensionsMap.update(_certificateExtensionsMapUpdate)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -58,6 +58,7 @@ suite = unittest.TestLoader().loadTestsFromNames(
      'tests.test_rfc6032.suite',
      'tests.test_rfc6210.suite',
      'tests.test_rfc6211.suite',
+     'tests.test_rfc6960.suite',
      'tests.test_rfc7030.suite',
      'tests.test_rfc7191.suite',
      'tests.test_rfc7229.suite',

--- a/tests/test_rfc6960.py
+++ b/tests/test_rfc6960.py
@@ -1,0 +1,169 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley
+# Copyright (c) 2019, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+
+import sys
+
+from pyasn1.codec.der.decoder import decode as der_decode
+from pyasn1.codec.der.encoder import encode as der_encode
+
+from pyasn1.type import univ
+
+from pyasn1_modules import pem
+from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc4055
+from pyasn1_modules import rfc6960
+
+try:
+    import unittest2 as unittest
+
+except ImportError:
+    import unittest
+
+
+class OCSPRequestTestCase(unittest.TestCase):
+    ocsp_req_pem_text = """\
+MGowaDBBMD8wPTAJBgUrDgMCGgUABBS3ZrMV9C5Dko03aH13cEZeppg3wgQUkqR1LKSevoFE63n8
+isWVpesQdXMCBDXe9M+iIzAhMB8GCSsGAQUFBzABAgQSBBBjdJOiIW9EKJGELNNf/rdA
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc6960.OCSPRequest()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.ocsp_req_pem_text)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encode(asn1Object) == substrate
+
+        assert asn1Object['tbsRequest']['version'] == 0
+
+        count = 0
+        for extn in asn1Object['tbsRequest']['requestExtensions']:
+            assert extn['extnID'] in rfc5280.certificateExtensionsMap.keys()
+            ev, rest = der_decode(extn['extnValue'],
+                asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
+            assert not rest
+            assert ev.prettyPrint()
+            assert der_encode(ev) == extn['extnValue']
+            count += 1
+
+        assert count == 1
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.ocsp_req_pem_text)
+        asn1Object, rest = der_decode(substrate,
+           asn1Spec=self.asn1Spec,
+           decodeOpenTypes=True)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encode(asn1Object) == substrate
+
+        assert asn1Object['tbsRequest']['version'] == 0
+        for req in  asn1Object['tbsRequest']['requestList']:
+            ha = req['reqCert']['hashAlgorithm']
+            assert ha['algorithm'] == rfc4055.id_sha1
+            assert ha['parameters'] == univ.Null("")
+
+
+class OCSPResponseTestCase(unittest.TestCase):
+    ocsp_resp_pem_text = """\
+MIIEvQoBAKCCBLYwggSyBgkrBgEFBQcwAQEEggSjMIIEnzCCAQ+hgYAwfjELMAkGA1UEBhMCQVUx
+EzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEV
+MBMGA1UEAxMMc25tcGxhYnMuY29tMSAwHgYJKoZIhvcNAQkBFhFpbmZvQHNubXBsYWJzLmNvbRgP
+MjAxMjA0MTExNDA5MjJaMFQwUjA9MAkGBSsOAwIaBQAEFLdmsxX0LkOSjTdofXdwRl6mmDfCBBSS
+pHUspJ6+gUTrefyKxZWl6xB1cwIENd70z4IAGA8yMDEyMDQxMTE0MDkyMlqhIzAhMB8GCSsGAQUF
+BzABAgQSBBBjdJOiIW9EKJGELNNf/rdAMA0GCSqGSIb3DQEBBQUAA4GBADk7oRiCy4ew1u0N52QL
+RFpW+tdb0NfkV2Xyu+HChKiTThZPr9ZXalIgkJ1w3BAnzhbB0JX/zq7Pf8yEz/OrQ4GGH7HyD3Vg
+PkMu+J6I3A2An+bUQo99AmCbZ5/tSHtDYQMQt3iNbv1fk0yvDmh7UdKuXUNSyJdHeg27dMNy4k8A
+oIIC9TCCAvEwggLtMIICVqADAgECAgEBMA0GCSqGSIb3DQEBBQUAMH4xCzAJBgNVBAYTAkFVMRMw
+EQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxFTAT
+BgNVBAMTDHNubXBsYWJzLmNvbTEgMB4GCSqGSIb3DQEJARYRaW5mb0Bzbm1wbGFicy5jb20wHhcN
+MTIwNDExMTMyNTM1WhcNMTMwNDExMTMyNTM1WjB+MQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29t
+ZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMRUwEwYDVQQDEwxzbm1w
+bGFicy5jb20xIDAeBgkqhkiG9w0BCQEWEWluZm9Ac25tcGxhYnMuY29tMIGfMA0GCSqGSIb3DQEB
+AQUAA4GNADCBiQKBgQDDDU5HOnNV8I2CojxB8ilIWRHYQuaAjnjrETMOprouDHFXnwWqQo/I3m0b
+XYmocrh9kDefb+cgc7+eJKvAvBqrqXRnU38DmQU/zhypCftGGfP8xjuBZ1n23lR3hplN1yYA0J2X
+SgBaAg6e8OsKf1vcX8Es09rDo8mQpt4G2zR56wIDAQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG
++EIBDQQfFh1PcGVuU1NMIEdlbmVyYXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQU8Ys2dpJFLMHl
+yY57D4BNmlqnEcYwHwYDVR0jBBgwFoAU8Ys2dpJFLMHlyY57D4BNmlqnEcYwDQYJKoZIhvcNAQEF
+BQADgYEAWR0uFJVlQId6hVpUbgXFTpywtNitNXFiYYkRRv77McSJqLCa/c1wnuLmqcFcuRUK0oN6
+8ZJDP2HDDKe8MCZ8+sx+CF54eM8VCgN9uQ9XyE7x9XrXDd3Uw9RJVaWSIezkNKNeBE0lDM2jUjC4
+HAESdf7nebz1wtqAOXE1jWF/y8g=
+"""
+
+    def setUp(self):
+        self.asn1Spec = rfc6960.OCSPResponse()
+
+    def testDerCodec(self):
+        substrate = pem.readBase64fromText(self.ocsp_resp_pem_text)
+        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encode(asn1Object) == substrate
+
+        assert asn1Object['responseStatus'] == 0
+        rb = asn1Object['responseBytes']
+        assert rb['responseType'] in rfc6960.ocspResponseMap.keys()
+        resp, rest = der_decode(rb['response'],
+                asn1Spec=rfc6960.ocspResponseMap[rb['responseType']])
+        assert not rest
+        assert resp.prettyPrint()
+        assert der_encode(resp) == rb['response']
+
+        resp['tbsResponseData']['version'] == 0
+        count = 0
+        for extn in resp['tbsResponseData']['responseExtensions']:
+            assert extn['extnID'] in rfc5280.certificateExtensionsMap.keys()
+            ev, rest = der_decode(extn['extnValue'],
+                asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
+            assert not rest
+            assert ev.prettyPrint()
+            assert der_encode(ev) == extn['extnValue']
+            count += 1
+
+        assert count == 1
+
+    def testOpenTypes(self):
+        substrate = pem.readBase64fromText(self.ocsp_resp_pem_text)
+        asn1Object, rest = der_decode(substrate,
+            asn1Spec=self.asn1Spec,
+            decodeOpenTypes=True)
+        assert not rest
+        assert asn1Object.prettyPrint()
+        assert der_encode(asn1Object) == substrate
+
+        assert asn1Object['responseStatus'] == 0
+        rb = asn1Object['responseBytes']
+        assert rb['responseType'] in rfc6960.ocspResponseMap.keys()
+        resp, rest = der_decode(rb['response'],
+                asn1Spec=rfc6960.ocspResponseMap[rb['responseType']],
+                decodeOpenTypes=True)
+        assert not rest
+        assert resp.prettyPrint()
+        assert der_encode(resp) == rb['response']
+
+        resp['tbsResponseData']['version'] == 0
+        for rdn in resp['tbsResponseData']['responderID']['byName']['rdnSequence']:
+            for attr in rdn:
+                if attr['type'] == rfc5280.id_emailAddress:
+                    assert attr['value'] == 'info@snmplabs.com'
+
+        for r in resp['tbsResponseData']['responses']:
+            ha = r['certID']['hashAlgorithm']
+            assert ha['algorithm'] == rfc4055.id_sha1
+            assert ha['parameters'] == univ.Null("")
+
+
+suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])
+
+if __name__ == '__main__':
+    import sys
+
+    result = unittest.TextTestRunner(verbosity=2).run(suite)
+    sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Add module and test for RFC 6960.  People should use RFC 6960 for OCSP instead of RFC 2560.