### PR TITLE
Declare support for Python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ __pycache__
 # vim swapfiles
 *.sw?
 
+# virtual environment
+.venv/
+
 # python packaging
 MANIFEST
 dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ matrix:
     dist: xenial
     python: '3.7'
   - os: linux
+    dist: bionic
+    python: '3.8'
+  - os: linux
     dist: trusty
     python: 'nightly'
   - os: linux

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Topic :: Communications
 Topic :: System :: Monitoring
 Topic :: System :: Networking :: Monitoring


### PR DESCRIPTION
Hello @etingof,

Python 3.8 is there, so I believe that it would be nice to declare support and add tests for it on CI.

Python 3.8.0 release announcement:
https://discuss.python.org/t/python-3-8-0-is-now-available/2478


These changes also:

 - add `.venv/` to `.gitignore`

Best regards!