### PR TITLE
Add support for RFC 6170

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,6 +12,8 @@ Revision 0.2.8, released XX-XX-2019
 - Updated the handling of maps for use with openType for RFC 3279
 - Added RFC6486 providing RPKI Manifests
 - Added RFC6487 providing Profile for X.509 PKIX Resource Certificates
+- Added RFC6170 providing Certificate Image in the Internet X.509 Public
+  Key Infrastructure, and import the object identifier into RFC3709.
 
 Revision 0.2.7, released 09-10-2019
 -----------------------------------

--- a/pyasn1_modules/rfc3709.py
+++ b/pyasn1_modules/rfc3709.py
@@ -21,6 +21,7 @@ from pyasn1.type import tag
 from pyasn1.type import univ
 
 from pyasn1_modules import rfc5280
+from pyasn1_modules import rfc6170
 
 MAX = float('inf')
 
@@ -161,6 +162,8 @@ LogotypeInfo.componentType = namedtype.NamedTypes(
 id_logo_background = univ.ObjectIdentifier('1.3.6.1.5.5.7.20.2')
 
 id_logo_loyalty = univ.ObjectIdentifier('1.3.6.1.5.5.7.20.1')
+
+id_logo_certImage = rfc6170.id_logo_certImage
 
 
 class OtherLogotypeInfo(univ.Sequence):

--- a/pyasn1_modules/rfc6170.py
+++ b/pyasn1_modules/rfc6170.py
@@ -1,0 +1,17 @@
+#
+# This file is part of pyasn1-modules software.
+#
+# Created by Russ Housley.
+#
+# Copyright (c) 2019, Vigil Security, LLC
+# License: http://snmplabs.com/pyasn1/license.html
+#
+# Certificate Image in the Internet X.509 Public Key Infrastructure
+#
+# ASN.1 source from:
+# https://www.rfc-editor.org/rfc/rfc6170.txt
+#
+
+from pyasn1.type import univ
+
+id_logo_certImage = univ.ObjectIdentifier('1.3.6.1.5.5.7.20.3')


### PR DESCRIPTION
Added a module for RFC 6170, providing Certificate Image in the Internet X.509 Public Key Infrastructure, and import the object identifier into RFC3709.  No additional test is offered.