### PR TITLE
Update to RFC 8226 for ComponentPresentConstraint

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,8 @@ Revision 0.2.8, released XX-XX-2019
 - Added RFC5924 providing Extended Key Usage for Session Initiation
   Protocol (SIP) in X.509 certificates
 - Added RFC5916 providing Device Owner Attribute
+- Update RFC8226 to use ComponentPresentConstraint() instead of the
+  previous work around
 
 Revision 0.2.7, released 09-10-2019
 -----------------------------------

--- a/pyasn1_modules/rfc8226.py
+++ b/pyasn1_modules/rfc8226.py
@@ -75,8 +75,12 @@ JWTClaimConstraints.componentType = namedtype.NamedTypes(
             tag.tagFormatSimple, 1)))
 )
 
-
-JWTClaimConstraints.sizeSpec = univ.Sequence.sizeSpec + constraint.ValueSizeConstraint(1, 2)
+JWTClaimConstraints.subtypeSpec = constraint.ConstraintsUnion(
+    constraint.WithComponentsConstraint(
+        ('mustInclude', constraint.ComponentPresentConstraint())),
+    constraint.WithComponentsConstraint(
+        ('permittedValues', constraint.ComponentPresentConstraint()))
+)
 
 
 id_pe_JWTClaimConstraints = _OID(1, 3, 6, 1, 5, 5, 7, 1, 27)


### PR DESCRIPTION
Use the recently added ComponentPresentConstraint() instead of the previous approach.