### PR TITLE
Remove 3.4 Trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ Operating System :: OS Independent
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7


### PR DESCRIPTION
EOL Python 3.4 was removed in https://github.com/hugovk/pyasn1-modules/commit/a6f62cc801d49e0f4ba087771aa7fbe7a80599cb#diff-2eeaed663bd0d25b7e608891384b7298, also remove the classifier for PyPI.