### PR TITLE
Use `unittest` assert methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Revision 0.3.0, released XX-11-2019
 - Removed support for EOL Pythons 2.4, 2.5, 2.6, 3.2, 3.3 and 3.4.
 - Improve test routines for RFC5126
 - Add RFC4387 providing Certificate Store Access via HTTP
+- Changed assertion in unit tests from Python built-in to `unittest`
+  provided
 
 Revision 0.2.8, released 16-11-2019
 -----------------------------------

--- a/tests/test_pem.py
+++ b/tests/test_pem.py
@@ -36,7 +36,7 @@ GGbx7DI=
 
         binary = pem.readBase64fromText(self.pem_text)
 
-        assert binary
+        self.assertTrue(binary)
 
         expected = [
             48, 130, 3, 1, 48, 130, 1, 233, 2, 1, 0, 48, 129, 153, 49, 11, 48,
@@ -93,7 +93,7 @@ GGbx7DI=
             24, 102, 241, 236, 50
         ]
 
-        assert ints2octs(expected) == binary
+        self.assertEqual(ints2octs(expected), binary)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc2314.py
+++ b/tests/test_rfc2314.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc2314
@@ -42,11 +42,11 @@ GGbx7DI=
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc2315.py
+++ b/tests/test_rfc2315.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc2315
@@ -141,21 +141,21 @@ Kv0xuR3b3Le+ZqolT8wQELd5Mmw5JPofZ+O2cGNvet8tYwOKFjEA
 
         substrate = pem.readBase64fromText(self.pem_text_unordered)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
     def testDerCodecDecodeOpenTypes(self):
 
         substrate = pem.readBase64fromText(self.pem_text_reordered)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(
-            asn1Object, omitEmptyOptionals=False) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(
+            substrate, der_encoder(asn1Object, omitEmptyOptionals=False))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc2437.py
+++ b/tests/test_rfc2437.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc2437
@@ -32,11 +32,11 @@ n8lDw3JT6NjvMnD6aM8KBsLyhazWSVVkaUSqmJzgCF0=
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc2459.py
+++ b/tests/test_rfc2459.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc2459
@@ -41,21 +41,22 @@ PhmcGcwTTYJBtYze4D1gCCAPRX5ron+jjBXu
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(der_encoder(asn1Object), substrate)
 
     def testDerCodecDecodeOpenTypes(self):
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(der_encoder(asn1Object), substrate)
 
 
 class CertificateListTestCase(unittest.TestCase):
@@ -77,21 +78,22 @@ vjnIhxTFoCb5vA==
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(der_encoder(asn1Object), substrate)
 
     def testDerCodecDecodeOpenTypes(self):
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(der_encoder(asn1Object), substrate)
 
 
 class DSAPrivateKeyTestCase(unittest.TestCase):
@@ -115,21 +117,22 @@ INow2I3/ks+0MxDabTY=
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
     def testDerCodecDecodeOpenTypes(self):
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc2511.py
+++ b/tests/test_rfc2511.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc2511
@@ -34,11 +34,11 @@ xfu5YVWi81/fw8QQ6X6YGHFQkomLd7jxakVyjxSng9BhO6GpjJNF
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc2560.py
+++ b/tests/test_rfc2560.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der import decoder as der_decoder
-from pyasn1.codec.der import encoder as der_encoder
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc2560
@@ -27,11 +27,11 @@ isWVpesQdXMCBDXe9M+iIzAhMB8GCSsGAQUFBzABAgQSBBBjdJOiIW9EKJGELNNf/rdA
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(der_encoder(asn1Object), substrate)
 
 
 class OCSPResponseTestCase(unittest.TestCase):
@@ -66,11 +66,11 @@ HAESdf7nebz1wtqAOXE1jWF/y8g=
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc2631.py
+++ b/tests/test_rfc2631.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 from pyasn1.type import univ
 
 from pyasn1_modules import pem
@@ -24,13 +24,14 @@ class OtherInfoTestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         hex1 = univ.OctetString(hexValue='00000001')
-        assert asn1Object['keyInfo']['counter'] == hex1
+        self.assertEqual(hex1, asn1Object['keyInfo']['counter'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3125.py
+++ b/tests/test_rfc3125.py
@@ -7,20 +7,14 @@
 #
 
 import sys
+import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc2985
 from pyasn1_modules import rfc3125
-
-
-try:
-    import unittest2 as unittest
-
-except ImportError:
-    import unittest
 
 
 class SignaturePolicyTestCase(unittest.TestCase):
@@ -91,17 +85,19 @@ BQQGAgIBADAABCAaWobQZ1EuANtF/NjfuaBXR0nR0fKnGJ7Z8t/mregtvQ==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         svp = asn1Object['signPolicyInfo']['signatureValidationPolicy']
         sr = svp['commonRules']['signerAndVeriferRules']['signerRules']
         msa = sr['mandatedSignedAttr']
-        assert rfc2985.pkcs_9_at_contentType in msa
-        assert rfc2985.pkcs_9_at_messageDigest in msa
-        assert rfc2985.pkcs_9_at_signingTime in msa
+
+        self.assertIn(rfc2985.pkcs_9_at_contentType, msa)
+        self.assertIn(rfc2985.pkcs_9_at_messageDigest, msa)
+        self.assertIn(rfc2985.pkcs_9_at_signingTime, msa)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3161.py
+++ b/tests/test_rfc3161.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc3161
@@ -26,10 +26,11 @@ t1zOHCvK4A8i8zxwUXFHv4pAJZE+uFhZ+v53HTg9rLjO5Q==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.tsp_query_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 class TSPResponseTestCase(unittest.TestCase):
@@ -66,10 +67,11 @@ uuvuO3ZsRWuej+gso+nWi3CRnRc9Wb0++cq4s8YSLaYSj2pHMA==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.tsp_response_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3279.py
+++ b/tests/test_rfc3279.py
@@ -9,8 +9,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 from pyasn1.type import univ
 
 from pyasn1_modules import pem
@@ -54,36 +54,41 @@ M2jlVZ6qW8swC53HD79oRIGXi1FK
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.rsa_cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.rsaEncryption
+
+        self.assertEqual(rfc3279.rsaEncryption, spki_a['algorithm'])
 
         spki_pk = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['subjectPublicKey'].asOctets()
-        pk, rest = der_decode(spki_pk, asn1Spec=rfc3279.RSAPublicKey())
-        assert not rest
-        assert pk.prettyPrint()
-        assert der_encode(pk) == spki_pk
-        assert pk['publicExponent'] == 65537
+        pk, rest = der_decoder(spki_pk, asn1Spec=rfc3279.RSAPublicKey())
 
-        assert asn1Object['tbsCertificate']['signature']['algorithm'] == rfc3279.sha1WithRSAEncryption
-        assert asn1Object['signatureAlgorithm']['algorithm'] == rfc3279.sha1WithRSAEncryption
+        self.assertFalse(rest)
+        self.assertTrue(pk.prettyPrint())
+        self.assertEqual(spki_pk, der_encoder(pk))
+        self.assertEqual(65537, pk['publicExponent'])
+        self.assertEqual(rfc3279.sha1WithRSAEncryption,
+                         asn1Object['tbsCertificate']['signature']['algorithm'])
+        self.assertEqual(rfc3279.sha1WithRSAEncryption,
+                         asn1Object['signatureAlgorithm']['algorithm'])
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.rsa_cert_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.rsaEncryption
-        assert spki_a['parameters'] == univ.Null("")
+
+        self.assertEqual(rfc3279.rsaEncryption, spki_a['algorithm'])
+        self.assertEqual(univ.Null(""), spki_a['parameters'])
 
 
 class ECCertificateTestCase(unittest.TestCase):
@@ -115,34 +120,38 @@ Ea8/B6hPatJ0ES8q/HO3X8IVQwVs1n3aAr0im0/T+Xc=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.ec_cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.id_ecPublicKey
 
-        spki_a_p, rest = der_decode(spki_a['parameters'],
-            asn1Spec=rfc3279.EcpkParameters())
-        assert not rest
-        assert spki_a_p.prettyPrint()
-        assert der_encode(spki_a_p) == spki_a['parameters']
-        assert spki_a_p['namedCurve'] == univ.ObjectIdentifier('1.3.132.0.34')
+        self.assertEqual(rfc3279.id_ecPublicKey, spki_a['algorithm'])
+
+        spki_a_p, rest = der_decoder(
+            spki_a['parameters'], asn1Spec=rfc3279.EcpkParameters())
+
+        self.assertFalse(rest)
+        self.assertTrue(spki_a_p.prettyPrint())
+        self.assertEqual(spki_a['parameters'], der_encoder(spki_a_p))
+        self.assertEqual(univ.ObjectIdentifier('1.3.132.0.34'), spki_a_p['namedCurve'])
 
     def testOpenTypes(self):
-        asn1Spec = rfc5280.Certificate()
         substrate = pem.readBase64fromText(self.ec_cert_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.id_ecPublicKey
-        assert spki_a['parameters']['namedCurve'] == univ.ObjectIdentifier('1.3.132.0.34')
+
+        self.assertEqual(rfc3279.id_ecPublicKey, spki_a['algorithm'])
+        self.assertEqual(
+            univ.ObjectIdentifier('1.3.132.0.34'), spki_a['parameters']['namedCurve'])
 
 
 class DSACertificateTestCase(unittest.TestCase):
@@ -174,43 +183,51 @@ pNqdXqZZGESXy1MT1aBc4ynPGLFUr2r7cPY=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.dsa_cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.id_dsa
 
-        spki_a_p, rest = der_decode(spki_a['parameters'],
-            asn1Spec=rfc3279.Dss_Parms())
-        assert not rest
-        assert spki_a_p.prettyPrint()
-        assert der_encode(spki_a_p) == spki_a['parameters']
+        self.assertEqual(rfc3279.id_dsa, spki_a['algorithm'])
+
+        spki_a_p, rest = der_decoder(spki_a['parameters'],
+                                     asn1Spec=rfc3279.Dss_Parms())
+        self.assertFalse(rest)
+        self.assertTrue(spki_a_p.prettyPrint())
+        self.assertEqual(spki_a['parameters'], der_encoder(spki_a_p))
+
         q_value = 1260916123897116834511257683105158021801897369967
-        assert spki_a_p['q'] == q_value
 
-        sig_value, rest = der_decode(asn1Object['signature'].asOctets(),
-            asn1Spec=rfc3279.Dss_Sig_Value())
-        assert not rest
-        assert sig_value.prettyPrint()
-        assert der_encode(sig_value) == asn1Object['signature'].asOctets()
-        assert sig_value['r'].hasValue()
-        assert sig_value['s'].hasValue()
+        self.assertEqual(q_value, spki_a_p['q'])
+
+        sig_value, rest = der_decoder(
+            asn1Object['signature'].asOctets(), asn1Spec=rfc3279.Dss_Sig_Value())
+
+        self.assertFalse(rest)
+        self.assertTrue(sig_value.prettyPrint())
+        self.assertEqual(asn1Object['signature'].asOctets(), der_encoder(sig_value))
+        self.assertTrue(sig_value['r'].hasValue())
+        self.assertTrue(sig_value['s'].hasValue())
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.dsa_cert_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.id_dsa
+
+        self.assertEqual(rfc3279.id_dsa, spki_a['algorithm'])
+
         q_value = 1260916123897116834511257683105158021801897369967
-        assert spki_a['parameters']['q'] == q_value
+
+        self.assertEqual(q_value, spki_a['parameters']['q'])
 
 
 class KEACertificateTestCase(unittest.TestCase):
@@ -235,49 +252,56 @@ TPnJ5Wym0hv2fOpnPPsWTgqvLFYfX27GGTquuOd/6A==
         self.asn1Spec = rfc5280.Certificate()
 
     def testDerCodec(self):
-        asn1Spec = rfc5280.Certificate()
         substrate = pem.readBase64fromText(self.kea_cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.id_keyExchangeAlgorithm
 
-        spki_a_p, rest = der_decode(spki_a['parameters'],
-            asn1Spec=rfc3279.KEA_Parms_Id())
-        assert not rest
-        assert spki_a_p.prettyPrint()
-        assert der_encode(spki_a_p) == spki_a['parameters']
-        assert spki_a_p == univ.OctetString(hexValue='5cf8f127e6569d6d88b3')
+        self.assertEqual(rfc3279.id_keyExchangeAlgorithm, spki_a['algorithm'])
 
-        assert asn1Object['tbsCertificate']['signature']['algorithm'] == rfc3279.id_dsa_with_sha1
-        assert asn1Object['signatureAlgorithm']['algorithm'] == rfc3279.id_dsa_with_sha1
+        spki_a_p, rest = der_decoder(spki_a['parameters'],
+                                     asn1Spec=rfc3279.KEA_Parms_Id())
+        self.assertFalse(rest)
+        self.assertTrue(spki_a_p.prettyPrint())
 
-        sig_value, rest = der_decode(asn1Object['signature'].asOctets(),
-            asn1Spec=rfc3279.Dss_Sig_Value())
-        assert not rest
-        assert sig_value.prettyPrint()
-        assert der_encode(sig_value) == asn1Object['signature'].asOctets()
-        assert sig_value['r'].hasValue()
-        assert sig_value['s'].hasValue()
+        self.assertEqual(spki_a['parameters'], der_encoder(spki_a_p))
+        self.assertEqual(univ.OctetString(hexValue='5cf8f127e6569d6d88b3'), spki_a_p)
+        self.assertEqual(
+            rfc3279.id_dsa_with_sha1, asn1Object['tbsCertificate']['signature']['algorithm'])
+        self.assertEqual(
+            rfc3279.id_dsa_with_sha1, asn1Object['signatureAlgorithm']['algorithm'])
+
+        sig_value, rest = der_decoder(asn1Object['signature'].asOctets(),
+                                      asn1Spec=rfc3279.Dss_Sig_Value())
+        self.assertFalse(rest)
+        self.assertTrue(sig_value.prettyPrint())
+        self.assertEqual(asn1Object['signature'].asOctets(), der_encoder(sig_value))
+        self.assertTrue(sig_value['r'].hasValue())
+        self.assertTrue(sig_value['s'].hasValue())
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.kea_cert_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.id_keyExchangeAlgorithm
-        assert spki_a['parameters'] == univ.OctetString(hexValue='5cf8f127e6569d6d88b3')
 
-        assert asn1Object['tbsCertificate']['signature']['algorithm'] == rfc3279.id_dsa_with_sha1
-        assert asn1Object['signatureAlgorithm']['algorithm'] == rfc3279.id_dsa_with_sha1
+        self.assertEqual(rfc3279.id_keyExchangeAlgorithm, spki_a['algorithm'])
+        self.assertEqual(
+            univ.OctetString(hexValue='5cf8f127e6569d6d88b3'), spki_a['parameters'])
+
+        self.assertEqual(rfc3279.id_dsa_with_sha1,
+                         asn1Object['tbsCertificate']['signature']['algorithm'])
+        self.assertEqual(
+            rfc3279.id_dsa_with_sha1, asn1Object['signatureAlgorithm']['algorithm'])
 
 
 class DHCertificateTestCase(unittest.TestCase):
@@ -315,35 +339,44 @@ iPEBA+EDHjk=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.dh_cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.dhpublicnumber
 
-        spki_a_p, rest = der_decode(spki_a['parameters'],
-            asn1Spec=rfc3279.DomainParameters())
-        assert not rest
-        assert spki_a_p.prettyPrint()
-        assert der_encode(spki_a_p) == spki_a['parameters']
+        self.assertEqual(rfc3279.dhpublicnumber, spki_a['algorithm'])
+
+        spki_a_p, rest = der_decoder(
+            spki_a['parameters'], asn1Spec=rfc3279.DomainParameters())
+
+        self.assertFalse(rest)
+        self.assertTrue(spki_a_p.prettyPrint())
+        self.assertEqual(spki_a['parameters'], der_encoder(spki_a_p))
+
         q_value = 65838278260281264030127352144753816831178774189428428256716126077244217603537
-        assert spki_a_p['q'] == q_value
+
+        self.assertEqual(q_value, spki_a_p['q'])
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.dh_cert_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate,
+                                       asn1Spec=self.asn1Spec,
+                                       decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         spki_a = asn1Object['tbsCertificate']['subjectPublicKeyInfo']['algorithm']
-        assert spki_a['algorithm'] == rfc3279.dhpublicnumber
+
+        self.assertEqual(rfc3279.dhpublicnumber, spki_a['algorithm'])
+
         q_value = 65838278260281264030127352144753816831178774189428428256716126077244217603537
-        assert spki_a['parameters']['q'] == q_value
+
+        self.assertEqual(q_value, spki_a['parameters']['q'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3280.py
+++ b/tests/test_rfc3280.py
@@ -9,8 +9,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc3280
@@ -41,10 +41,11 @@ PhmcGcwTTYJBtYze4D1gCCAPRX5ron+jjBXu
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 class CertificateListTestCase(unittest.TestCase):
@@ -64,10 +65,11 @@ vjnIhxTFoCb5vA==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3447.py
+++ b/tests/test_rfc3447.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc3447
@@ -52,10 +52,11 @@ EeEs9dusHakg1ERXAg4Vo1YowPW8kuVbZ9faxeVrmuER5NcCuZzS5X/obGUw
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3560.py
+++ b/tests/test_rfc3560.py
@@ -25,11 +25,10 @@ class OAEPDefautTestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.oaep_default_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc3560.id_RSAES_OAEP
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc3560.id_RSAES_OAEP, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 class OAEPSHA256TestCase(unittest.TestCase):
@@ -41,11 +40,10 @@ class OAEPSHA256TestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.oaep_sha256_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc3560.id_RSAES_OAEP
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc3560.id_RSAES_OAEP, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 class OAEPFullTestCase(unittest.TestCase):
@@ -57,11 +55,10 @@ class OAEPFullTestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.oaep_full_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc3560.id_RSAES_OAEP
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc3560.id_RSAES_OAEP, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3565.py
+++ b/tests/test_rfc3565.py
@@ -25,10 +25,10 @@ class AESKeyWrapTestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.kw_alg_id_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc3565.id_aes256_wrap
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc3565.id_aes256_wrap, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 class AESCBCTestCase(unittest.TestCase):
@@ -40,23 +40,26 @@ class AESCBCTestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.aes_alg_id_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc3565.id_aes256_CBC
-        assert asn1Object[1].isValue
-        assert der_encoder.encode(asn1Object) == substrate
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc3565.id_aes256_CBC, asn1Object[0])
+        self.assertTrue(asn1Object[1].isValue)
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.aes_alg_id_pem_text)
         asn1Object, rest = der_decoder.decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc3565.id_aes256_CBC
+            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc3565.id_aes256_CBC, asn1Object[0])
+
         aes_iv = univ.OctetString(hexValue='108996ba850e3f0339993bb5878a0e37')
-        assert asn1Object[1] == aes_iv
-        assert der_encoder.encode(asn1Object) == substrate
+
+        self.assertEqual(aes_iv, asn1Object[1])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3709.py
+++ b/tests/test_rfc3709.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5280
@@ -40,39 +40,49 @@ Pj22pmfmQi5w21UljqoTj/+lQLkU3wfy5BdVKBwI0GfEA+YL3ctSzPNqAA==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        extn_list = [ ]
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        extn_list = []
+
         for extn in asn1Object['tbsCertificate']['extensions']:
             extn_list.append(extn['extnID'])
 
             if extn['extnID'] == rfc3709.id_pe_logotype:
                 s = extn['extnValue']
-                logotype, rest = der_decode(s, rfc3709.LogotypeExtn())
-                assert not rest
-                assert logotype.prettyPrint()
-                assert der_encode(logotype) == s
-                ids = logotype['subjectLogo']['direct']['image'][0]['imageDetails']
-                assert ids['mediaType'] == "image/png"
-                assert ids['logotypeURI'][0] == "http://www.vigilsec.com/vigilsec_logo.png"
+                logotype, rest = der_decoder(s, rfc3709.LogotypeExtn())
 
-        assert rfc3709.id_pe_logotype in extn_list
+                self.assertFalse(rest)
+                self.assertTrue(logotype.prettyPrint())
+                self.assertEqual(s, der_encoder(logotype))
+
+                ids = logotype['subjectLogo']['direct']['image'][0]['imageDetails']
+
+                self.assertEqual( "image/png", ids['mediaType'])
+
+                expected = "http://www.vigilsec.com/vigilsec_logo.png"
+                self.assertEqual(expected, ids['logotypeURI'][0])
+
+        self.assertIn(rfc3709.id_pe_logotype, extn_list)
 
     def testExtensionsMap(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         for extn in asn1Object['tbsCertificate']['extensions']:
             if extn['extnID'] in rfc5280.certificateExtensionsMap.keys():
-                extnValue, rest = der_decode(extn['extnValue'],
+                extnValue, rest = der_decoder(
+                    extn['extnValue'],
                     asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
-                assert der_encode(extnValue) == extn['extnValue']
+
+                self.assertEqual(extn['extnValue'], der_encoder(extnValue))
 
 
 class CertificateExtnWithDataTestCase(unittest.TestCase):
@@ -133,39 +143,48 @@ kbpmR6cDliloU808Bi/erMkrfUHRoZ2d586lkmwkLcoDkJ/yPD+Jhw==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        extn_list = [ ]
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        extn_list = []
+
         for extn in asn1Object['tbsCertificate']['extensions']:
             extn_list.append(extn['extnID'])
 
             if extn['extnID'] == rfc3709.id_pe_logotype:
                 s = extn['extnValue']
-                logotype, rest = der_decode(s, rfc3709.LogotypeExtn())
-                assert not rest
-                assert logotype.prettyPrint()
-                assert der_encode(logotype) == s
-                ids = logotype['subjectLogo']['direct']['image'][0]['imageDetails']
-                assert ids['mediaType'] == "image/svg+xml"
-                assert ids['logotypeURI'][0][0:25] == "data:image/svg+xml;base64"
+                logotype, rest = der_decoder(s, rfc3709.LogotypeExtn())
+                self.assertFalse(rest)
 
-        assert rfc3709.id_pe_logotype in extn_list
+                self.assertTrue(logotype.prettyPrint())
+                self.assertEqual(s, der_encoder(logotype))
+
+                ids = logotype['subjectLogo']['direct']['image'][0]['imageDetails']
+
+                self.assertEqual("image/svg+xml", ids['mediaType'])
+                self.assertEqual(
+                    "data:image/svg+xml;base64", ids['logotypeURI'][0][0:25])
+
+        self.assertIn(rfc3709.id_pe_logotype, extn_list)
 
     def testExtensionsMap(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         for extn in asn1Object['tbsCertificate']['extensions']:
             if extn['extnID'] in rfc5280.certificateExtensionsMap.keys():
-                extnValue, rest = der_decode(extn['extnValue'],
+                extnValue, rest = der_decoder(
+                    extn['extnValue'],
                     asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
-                assert der_encode(extnValue) == extn['extnValue']
+
+                self.assertEqual(extn['extnValue'], der_encoder(extnValue))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3779.py
+++ b/tests/test_rfc3779.py
@@ -50,46 +50,45 @@ V+vo2L72yerdbsP9xjqvhZrLKfsLZjYK4SdYYthi
 
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
-        extn_list = [ ]
+        extn_list = []
         for extn in asn1Object['tbsCertificate']['extensions']:
             extn_list.append(extn['extnID'])
 
             if extn['extnID'] == rfc3779.id_pe_ipAddrBlocks:
                 s = extn['extnValue']
                 addr_blocks, rest = der_decoder.decode(s, rfc3779.IPAddrBlocks())
-                assert not rest
-                assert addr_blocks.prettyPrint()
-                assert der_encoder.encode(addr_blocks) == s
+                self.assertFalse(rest)
+                self.assertTrue(addr_blocks.prettyPrint())
+                self.assertEqual(s, der_encoder.encode(addr_blocks))
 
             if extn['extnID'] == rfc3779.id_pe_autonomousSysIds:
                 s = extn['extnValue']
                 as_ids, rest = der_decoder.decode(s, rfc3779.ASIdentifiers())
-                assert not rest
-                assert as_ids.prettyPrint()
-                assert der_encoder.encode(as_ids) == s
+                self.assertFalse(rest)
+                self.assertTrue(as_ids.prettyPrint())
+                self.assertEqual(s, der_encoder.encode(as_ids))
 
-        assert rfc3779.id_pe_ipAddrBlocks in extn_list
-        assert rfc3779.id_pe_autonomousSysIds in extn_list
-
+        self.assertIn(rfc3779.id_pe_ipAddrBlocks, extn_list)
+        self.assertIn(rfc3779.id_pe_autonomousSysIds, extn_list)
 
     def testExtensionsMap(self):
         substrate = pem.readBase64fromText(self.pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
         for extn in asn1Object['tbsCertificate']['extensions']:
-            if extn['extnID'] == rfc3779.id_pe_ipAddrBlocks or \
-               extn['extnID'] == rfc3779.id_pe_autonomousSysIds:
-
-                extnValue, rest = der_decoder.decode(extn['extnValue'],
+            if (extn['extnID'] == rfc3779.id_pe_ipAddrBlocks or
+                    extn['extnID'] == rfc3779.id_pe_autonomousSysIds):
+                extnValue, rest = der_decoder.decode(
+                    extn['extnValue'],
                     asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
-                assert der_encoder.encode(extnValue) == extn['extnValue']
+                self.assertEqual(extn['extnValue'], der_encoder.encode(extnValue))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc4055.py
+++ b/tests/test_rfc4055.py
@@ -26,48 +26,52 @@ class PSSDefautTestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pss_default_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc4055.id_RSASSA_PSS
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertTrue(rfc4055.id_RSASSA_PSS, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.pss_default_pem_text)
         asn1Object, rest = der_decoder.decode(substrate,
                                               asn1Spec=self.asn1Spec,
                                               decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        assert not asn1Object['parameters'].hasValue()
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertFalse(asn1Object['parameters'].hasValue())
 
 
 class PSSSHA512TestCase(unittest.TestCase):
-    pss_sha512_pem_text = "MDwGCSqGSIb3DQEBCjAvoA8wDQYJYIZIAWUDBAIDBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAIDBQA="
+    pss_sha512_pem_text = "MDwGCSqGSIb3DQEBCjAvoA8wDQYJYIZIAWUDBAIDBQChHDAaBg" \
+                          "kqhkiG9w0BAQgwDQYJYIZIAWUDBAIDBQA="
 
     def setUp(self):
         self.asn1Spec = rfc5280.AlgorithmIdentifier()
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pss_sha512_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc4055.id_RSASSA_PSS
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertTrue(rfc4055.id_RSASSA_PSS, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.pss_sha512_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate,
-                                              asn1Spec=self.asn1Spec,
-                                              decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        assert asn1Object['parameters'].hasValue()
-        assert asn1Object['parameters']['saltLength'] == 20
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertTrue(asn1Object['parameters'].hasValue())
+        self.assertTrue(20, asn1Object['parameters']['saltLength'])
 
 
 class OAEPDefautTestCase(unittest.TestCase):
@@ -79,25 +83,26 @@ class OAEPDefautTestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.oaep_default_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc4055.id_RSAES_OAEP
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertTrue(rfc4055.id_RSAES_OAEP, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.oaep_default_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate,
-                                              asn1Spec=self.asn1Spec,
-                                              decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        assert not asn1Object['parameters'].hasValue()
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertFalse(asn1Object['parameters'].hasValue())
 
 
 class OAEPSHA256TestCase(unittest.TestCase):
-    oaep_sha256_pem_text = "MDwGCSqGSIb3DQEBBzAvoA8wDQYJYIZIAWUDBAIBBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAIBBQA="
+    oaep_sha256_pem_text = "MDwGCSqGSIb3DQEBBzAvoA8wDQYJYIZIAWUDBAIBBQChHDAaB" \
+                           "gkqhkiG9w0BAQgwDQYJYIZIAWUDBAIBBQA="
 
     def setUp(self):
         self.asn1Spec = rfc5280.AlgorithmIdentifier()
@@ -105,28 +110,33 @@ class OAEPSHA256TestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.oaep_sha256_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc4055.id_RSAES_OAEP
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertTrue(rfc4055.id_RSAES_OAEP, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.oaep_sha256_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate,
-                                              asn1Spec=self.asn1Spec,
-                                              decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        assert asn1Object['parameters'].hasValue()
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertTrue(asn1Object['parameters'].hasValue())
+
         oaep_p = asn1Object['parameters']
-        assert oaep_p['hashFunc']['parameters'] == univ.Null("")
-        assert oaep_p['maskGenFunc']['parameters']['parameters'] == univ.Null("")
+
+        self.assertEqual(univ.Null(""), oaep_p['hashFunc']['parameters'])
+        self.assertEqual(univ.Null(""), oaep_p['maskGenFunc']['parameters']['parameters'])
 
 
 class OAEPFullTestCase(unittest.TestCase):
-    oaep_full_pem_text = "MFMGCSqGSIb3DQEBBzBGoA8wDQYJYIZIAWUDBAICBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiFTATBgkqhkiG9w0BAQkEBmZvb2Jhcg=="
+    oaep_full_pem_text = "MFMGCSqGSIb3DQEBBzBGoA8wDQYJYIZIAWUDBAICBQChHDAaBgk" \
+                         "qhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiFTATBgkqhkiG9w0BAQ" \
+                         "kEBmZvb2Jhcg=="
 
     def setUp(self):
         self.asn1Spec = rfc5280.AlgorithmIdentifier()
@@ -134,25 +144,34 @@ class OAEPFullTestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.oaep_full_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc4055.id_RSAES_OAEP
-        assert der_encoder.encode(asn1Object) == substrate
-        assert substrate == der_encoder.encode(asn1Object)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+
+        self.assertTrue(rfc4055.id_RSAES_OAEP, asn1Object[0])
+
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.oaep_full_pem_text)
         asn1Object, rest = der_decoder.decode(substrate,
                                               asn1Spec=self.asn1Spec,
                                               decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        assert asn1Object['parameters'].hasValue()
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+
+        self.assertTrue(asn1Object['parameters'].hasValue())
+
         oaep_p = asn1Object['parameters']
-        assert oaep_p['hashFunc']['parameters'] == univ.Null("")
-        assert oaep_p['maskGenFunc']['parameters']['parameters'] == univ.Null("")
-        assert oaep_p['pSourceFunc']['parameters'] == univ.OctetString(value='foobar')
+
+        self.assertEqual(univ.Null(""), oaep_p['hashFunc']['parameters'])
+        self.assertEqual(
+            univ.Null(""), oaep_p['maskGenFunc']['parameters']['parameters'])
+        self.assertEqual(
+            univ.OctetString(value='foobar'),
+            oaep_p['pSourceFunc']['parameters'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc4210.py
+++ b/tests/test_rfc4210.py
@@ -116,9 +116,9 @@ JA5RSwQoMDYTj2WrwtM/nsP12T39or4JRZhlLSM43IaTwEBtQw==
 
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc4211.py
+++ b/tests/test_rfc4211.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc4211
@@ -33,17 +33,19 @@ xfu5YVWi81/fw8QQ6X6YGHFQkomLd7jxakVyjxSng9BhO6GpjJNF
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         count = 0
+
         for crm in asn1Object:
-            assert crm['certReq']['certTemplate']['version'] == 2
+            self.assertEqual(2, crm['certReq']['certTemplate']['version'])
             count += 1
 
-        assert count == 1
+        self.assertEqual(1, count)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc4334.py
+++ b/tests/test_rfc4334.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 from pyasn1.compat.octets import str2octs
 
 from pyasn1_modules import pem
@@ -41,37 +41,40 @@ DAlVlhox680Jxy5J8Pkx
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.cert_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        extn_list = [ ]
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        extn_list = []
+
         for extn in asn1Object['tbsCertificate']['extensions']:
             extn_list.append(extn['extnID'])
             if extn['extnID'] in rfc5280.certificateExtensionsMap.keys():
-                extnValue, rest = der_decode(extn['extnValue'],
+                extnValue, rest = der_decoder(
+                    extn['extnValue'],
                     asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
-                assert der_encode(extnValue) == extn['extnValue']
+
+                self.assertEqual(extn['extnValue'], der_encoder(extnValue))
 
                 if extn['extnID'] == rfc4334.id_pe_wlanSSID:
-                    assert str2octs('Example') in extnValue
+                    self.assertIn( str2octs('Example'), extnValue)
             
                 if extn['extnID'] == rfc5280.id_ce_extKeyUsage:
-                     assert rfc4334.id_kp_eapOverLAN in extnValue
-                     assert rfc4334.id_kp_eapOverPPP in extnValue
+                    self.assertIn(rfc4334.id_kp_eapOverLAN, extnValue)
+                    self.assertIn(rfc4334.id_kp_eapOverPPP, extnValue)
 
-        assert rfc4334.id_pe_wlanSSID in extn_list
-        assert rfc5280.id_ce_extKeyUsage in extn_list
+        self.assertIn(rfc4334.id_pe_wlanSSID, extn_list)
+        self.assertIn(rfc5280.id_ce_extKeyUsage, extn_list)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5035.py
+++ b/tests/test_rfc5035.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5652
@@ -56,26 +56,28 @@ T9yMtRLN5ZDU14y+Phzq9NKpSw/x5KyXoUKjCMc3Ru6dIW+CgcRQees+dhnvuD5U
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.signed_message_pem_text)
-        asn1Object, rest = der_decode (substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder (substrate, asn1Spec=self.asn1Spec)
 
-        assert asn1Object['contentType'] == rfc5652.id_signedData
-        sd, rest = der_decode(asn1Object['content'], asn1Spec=rfc5652.SignedData())
-        assert not rest
-        assert sd.prettyPrint()
-        assert der_encode(sd) == asn1Object['content'] 
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(rfc5652.id_signedData, asn1Object['contentType'])
+
+        sd, rest = der_decoder(asn1Object['content'], asn1Spec=rfc5652.SignedData())
+
+        self.assertFalse(rest)
+        self.assertTrue(sd.prettyPrint())
+        self.assertEqual(asn1Object['content'], der_encoder(sd))
        
         for sa in sd['signerInfos'][0]['signedAttrs']:
             sat = sa['attrType']
             sav0 = sa['attrValues'][0]
 
             if sat in rfc5652.cmsAttributesMap.keys():
-                sav, rest = der_decode(sav0, asn1Spec=rfc5652.cmsAttributesMap[sat])
-                assert not rest
-                assert sav.prettyPrint()
-                assert der_encode(sav) == sav0
+                sav, rest = der_decoder(sav0, asn1Spec=rfc5652.cmsAttributesMap[sat])
+                self.assertFalse(rest)
+                self.assertTrue(sav.prettyPrint())
+                self.assertEqual(sav0, der_encoder(sav))
 
 
 class SignedReceiptTestCase(unittest.TestCase):
@@ -111,60 +113,76 @@ vFIgX7eIkd8=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.signed_receipt_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert asn1Object['contentType'] == rfc5652.id_signedData
-        sd, rest = der_decode (asn1Object['content'], asn1Spec=rfc5652.SignedData())
-        assert not rest
-        assert sd.prettyPrint()
-        assert der_encode(sd) == asn1Object['content']
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
-        assert sd['encapContentInfo']['eContentType'] == rfc5035.id_ct_receipt
-        receipt, rest = der_decode(sd['encapContentInfo']['eContent'],
-                                   asn1Spec=rfc5035.Receipt())
-        assert not rest
-        assert receipt.prettyPrint()
-        assert der_encode(receipt) == sd['encapContentInfo']['eContent']
+        self.assertEqual(rfc5652.id_signedData, asn1Object['contentType'])
+
+        sd, rest = der_decoder(
+            asn1Object['content'], asn1Spec=rfc5652.SignedData())
+
+        self.assertFalse(rest)
+        self.assertTrue(sd.prettyPrint())
+        self.assertEqual(asn1Object['content'], der_encoder(sd))
+        self.assertEqual(
+            rfc5035.id_ct_receipt, sd['encapContentInfo']['eContentType'])
+
+        receipt, rest = der_decoder(
+            sd['encapContentInfo']['eContent'], asn1Spec=rfc5035.Receipt())
+
+        self.assertFalse(rest)
+        self.assertTrue(receipt.prettyPrint())
+        self.assertEqual(
+            sd['encapContentInfo']['eContent'], der_encoder(receipt))
 
         for sa in sd['signerInfos'][0]['signedAttrs']:
             sat = sa['attrType']
             sav0 = sa['attrValues'][0]
 
             if sat in rfc5652.cmsAttributesMap.keys():
-                sav, rest = der_decode(sav0, asn1Spec=rfc5652.cmsAttributesMap[sat])
-                assert not rest
-                assert sav.prettyPrint()
-                assert der_encode(sav) == sav0
+                sav, rest = der_decoder(
+                    sav0, asn1Spec=rfc5652.cmsAttributesMap[sat])
+                self.assertFalse(rest)
+                self.assertTrue(sav.prettyPrint())
+                self.assertEqual(sav0, der_encoder(sav))
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.signed_receipt_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec, decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        assert asn1Object['contentType'] in rfc5652.cmsContentTypesMap.keys()
-        assert asn1Object['contentType'] == rfc5652.id_signedData
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        self.assertIn(asn1Object['contentType'], rfc5652.cmsContentTypesMap)
+        self.assertEqual(rfc5652.id_signedData, asn1Object['contentType'])
 
         sd = asn1Object['content']
-        assert sd['version'] == rfc5652.CMSVersion().subtype(value='v3')
-        assert sd['encapContentInfo']['eContentType'] in rfc5652.cmsContentTypesMap.keys()
-        assert sd['encapContentInfo']['eContentType'] == rfc5035.id_ct_receipt
+
+        self.assertEqual(
+            rfc5652.CMSVersion().subtype(value='v3'), sd['version'])
+        self.assertIn(
+            sd['encapContentInfo']['eContentType'], rfc5652.cmsContentTypesMap)
+        self.assertEqual(
+            rfc5035.id_ct_receipt, sd['encapContentInfo']['eContentType'])
 
         for sa in sd['signerInfos'][0]['signedAttrs']:
-            assert sa['attrType'] in rfc5652.cmsAttributesMap.keys()
+            self.assertIn(sa['attrType'], rfc5652.cmsAttributesMap)
             if sa['attrType'] == rfc5035.id_aa_msgSigDigest:
-                sa['attrValues'][0].prettyPrint()[:10] == '0x167378'
+                self.assertIn(
+                    '0x167378', sa['attrValues'][0].prettyPrint()[:10])
 
         # Since receipt is inside an OCTET STRING, decodeOpenTypes=True cannot
         # automatically decode it 
-        receipt, rest = der_decode(sd['encapContentInfo']['eContent'],
+        receipt, rest = der_decoder(
+            sd['encapContentInfo']['eContent'],
             asn1Spec=rfc5652.cmsContentTypesMap[sd['encapContentInfo']['eContentType']])
-        assert receipt['version'] == 1
+
+        self.assertEqual(1, receipt['version'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5208.py
+++ b/tests/test_rfc5208.py
@@ -33,11 +33,12 @@ VWRpRKqYnOAIXQ==
 
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 class EncryptedPrivateKeyInfoInfoTestCase(unittest.TestCase):
@@ -59,11 +60,12 @@ dLsZjNQ=
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5649.py
+++ b/tests/test_rfc5649.py
@@ -23,11 +23,13 @@ class AESKeyWrapTestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.kw_alg_id_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc5649.id_aes256_wrap
-        assert der_encoder.encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc5649.id_aes256_wrap, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 class AESKeyWrapWithPadTestCase(unittest.TestCase):
@@ -38,11 +40,13 @@ class AESKeyWrapWithPadTestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.kw_pad_alg_id_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc5649.id_aes256_wrap_pad
-        assert der_encoder.encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc5649.id_aes256_wrap_pad, asn1Object[0])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5652.py
+++ b/tests/test_rfc5652.py
@@ -74,9 +74,9 @@ xicQmJP+VoMHo/ZpjFY9fYCjNZUArgKsEwK/s+p9yrVVeB1Nf8Mn
                 substrate, asn1Spec=layers[next_layer]
             )
 
-            assert not rest
-            assert asn1Object.prettyPrint()
-            assert der_encoder.encode(asn1Object) == substrate
+            self.assertFalse(rest)
+            self.assertTrue(asn1Object.prettyPrint())
+            self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
             substrate = getNextSubstrate[next_layer](asn1Object)
             next_layer = getNextLayer[next_layer](asn1Object)
@@ -118,40 +118,48 @@ xicQmJP+VoMHo/ZpjFY9fYCjNZUArgKsEwK/s+p9yrVVeB1Nf8Mn
         substrate = pem.readBase64fromText(self.pem_text)
         asn1Object, rest = der_decoder.decode(substrate,
             asn1Spec=rfc5652.ContentInfo(), decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
         eci = asn1Object['content']['encapContentInfo']
-        assert eci['eContentType'] in rfc5652.cmsContentTypesMap.keys()
-        assert eci['eContentType'] == rfc6402.id_cct_PKIData
+
+        self.assertIn(eci['eContentType'], rfc5652.cmsContentTypesMap)
+        self.assertEqual(rfc6402.id_cct_PKIData, eci['eContentType'])
+
         pkid, rest = der_decoder.decode(eci['eContent'],
             asn1Spec=rfc5652.cmsContentTypesMap[eci['eContentType']],
             openTypes=openTypeMap,
             decodeOpenTypes=True)
-        assert not rest
-        assert pkid.prettyPrint()
-        assert der_encoder.encode(pkid) == eci['eContent']
+
+        self.assertFalse(rest)
+        self.assertTrue(pkid.prettyPrint())
+        self.assertEqual(eci['eContent'], der_encoder.encode(pkid))
 
         for req in pkid['reqSequence']:
             cr = req['tcr']['certificationRequest']
 
             sig_alg = cr['signatureAlgorithm']
-            assert sig_alg['algorithm'] in openTypeMap.keys()
-            assert sig_alg['parameters'] == univ.Null("")
+
+            self.assertIn(sig_alg['algorithm'], openTypeMap)
+            self.assertEqual(univ.Null(""), sig_alg['parameters'])
 
             cri = cr['certificationRequestInfo']
             spki_alg = cri['subjectPublicKeyInfo']['algorithm']
-            assert spki_alg['algorithm'] in openTypeMap.keys()
-            assert spki_alg['parameters'] == univ.Null("")
+
+            self.assertIn( spki_alg['algorithm'], openTypeMap)
+            self.assertEqual(univ.Null(""), spki_alg['parameters'])
 
             attrs = cr['certificationRequestInfo']['attributes']
+
             for attr in attrs:
-                assert attr['attrType'] in openTypeMap.keys()
+                self.assertIn(attr['attrType'], openTypeMap)
+
                 if attr['attrType'] == univ.ObjectIdentifier('1.3.6.1.4.1.311.13.2.3'):
-                    assert attr['attrValues'][0] == "6.2.9200.2"
+                    self.assertEqual("6.2.9200.2", attr['attrValues'][0])
+
                 else:
-                    assert attr['attrValues'][0].hasValue()
+                    self.assertTrue(attr['attrValues'][0].hasValue())
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5914.py
+++ b/tests/test_rfc5914.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5914
@@ -58,18 +58,19 @@ IEVDQyBTZWN1cmUgU2VydmVyIENBggIFIIICZW4=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.trust_anchor_list_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert asn1Object['contentType'] == rfc5914.id_ct_trustAnchorList
-        tal, rest = der_decode(asn1Object['content'], rfc5914.TrustAnchorList())
-        assert not rest
-        assert tal.prettyPrint()
-        assert der_encode(tal) == asn1Object['content']
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(rfc5914.id_ct_trustAnchorList, asn1Object['contentType'])
 
-        assert sum (1 for _ in tal) == 3
+        tal, rest = der_decoder(asn1Object['content'], rfc5914.TrustAnchorList())
+
+        self.assertFalse(rest)
+        self.assertTrue(tal.prettyPrint())
+        self.assertEqual(asn1Object['content'], der_encoder(tal))
+        self.assertEqual(3, sum(1 for _ in tal))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5915.py
+++ b/tests/test_rfc5915.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5915
@@ -29,12 +29,13 @@ yDYOFDuqz/C2jyEwqgWCRyxyohuJXtk=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.private_key_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert asn1Object['parameters']['namedCurve'] == rfc5480.secp384r1
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(
+            rfc5480.secp384r1, asn1Object['parameters']['namedCurve'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc5924.py
+++ b/tests/test_rfc5924.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5280
@@ -39,24 +39,32 @@ UwZ6TjS0Rfr+dRvlyilVjP+hPVwbyb7ZOSZR6zk=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         found_kp_sipDomain = False
+
         for extn in asn1Object['tbsCertificate']['extensions']:
             if extn['extnID'] == rfc5280.id_ce_extKeyUsage:
-                assert extn['extnID'] in rfc5280.certificateExtensionsMap.keys()
-                ev, rest = der_decode(extn['extnValue'],
+                self.assertIn(
+                    extn['extnID'], rfc5280.certificateExtensionsMap)
+
+                ev, rest = der_decoder(
+                    extn['extnValue'],
                     asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
-                assert not rest
-                assert ev.prettyPrint()
-                assert der_encode(ev) == extn['extnValue']
-                assert rfc5924.id_kp_sipDomain in ev
+
+                self.assertFalse(rest)
+                self.assertTrue(ev.prettyPrint())
+                self.assertEqual(extn['extnValue'], der_encoder(ev))
+                self.assertIn(rfc5924.id_kp_sipDomain, ev)
+
                 found_kp_sipDomain = True
 
-        assert found_kp_sipDomain
+        self.assertTrue(found_kp_sipDomain)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc6031.py
+++ b/tests/test_rfc6031.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5652
@@ -29,50 +29,57 @@ DARIT1RQMCAGCyqGSIb3DQEJEAwLMREMD2t0YS5leGFtcGxlLmNvbQQEMTIzNA==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.key_pkg_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
-    
-        assert asn1Object['contentType'] in rfc5652.cmsContentTypesMap
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertIn(asn1Object['contentType'], rfc5652.cmsContentTypesMap)
+
         asn1Spec = rfc5652.cmsContentTypesMap[asn1Object['contentType']]
-        skp, rest = der_decode(asn1Object['content'], asn1Spec=asn1Spec)
-        assert not rest
-        assert skp.prettyPrint()
-        assert der_encode(skp) == asn1Object['content']
+        skp, rest = der_decoder(asn1Object['content'], asn1Spec=asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(skp.prettyPrint())
+        self.assertEqual(asn1Object['content'], der_encoder(skp))
 
         for attr in skp['sKeyPkgAttrs']:
-            assert attr['attrType'] in rfc6031.sKeyPkgAttributesMap.keys()
+            self.assertIn(attr['attrType'], rfc6031.sKeyPkgAttributesMap)
 
         for osk in skp['sKeys']:
             for attr in osk['sKeyAttrs']:
-                assert attr['attrType'] in rfc6031.sKeyAttributesMap.keys()
+                self.assertIn(attr['attrType'], rfc6031.sKeyAttributesMap)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.key_pkg_pem_text)
-        asn1Object, rest = der_decode(substrate, 
-                                      asn1Spec=self.asn1Spec,
-                                      decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        assert asn1Object['contentType'] in rfc5652.cmsContentTypesMap
-        assert asn1Object['content'].hasValue()
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertIn(asn1Object['contentType'], rfc5652.cmsContentTypesMap)
+        self.assertTrue(asn1Object['content'].hasValue())
+
         keypkg = asn1Object['content']
-        assert keypkg['version'] == rfc6031.KeyPkgVersion().subtype(value='v1')
+
+        self.assertEqual(
+            rfc6031.KeyPkgVersion().subtype(value='v1'), keypkg['version'])
 
         for attr in keypkg['sKeyPkgAttrs']:
-            assert attr['attrType'] in rfc6031.sKeyPkgAttributesMap.keys()
-            assert attr['attrValues'][0].prettyPrint()[:2] != '0x'
+            self.assertIn(attr['attrType'], rfc6031.sKeyPkgAttributesMap)
+            self.assertNotEqual('0x', attr['attrValues'][0].prettyPrint()[:2])
+
             # decodeOpenTypes=True did not decode if the value is shown in hex ...
             if attr['attrType'] == rfc6031.id_pskc_manufacturer:
                 attr['attrValues'][0] == 'Vigil Security LLC'
 
         for osk in keypkg['sKeys']:
             for attr in osk['sKeyAttrs']:
-                assert attr['attrType'] in rfc6031.sKeyAttributesMap.keys()
-                assert attr['attrValues'][0].prettyPrint()[:2] != '0x'
+                self.assertIn(attr['attrType'], rfc6031.sKeyAttributesMap)
+                self.assertNotEqual(
+                    '0x', attr['attrValues'][0].prettyPrint()[:2])
+
                 # decodeOpenTypes=True did not decode if the value is shown in hex ...
                 if attr['attrType'] == rfc6031.id_pskc_issuer:
                     attr['attrValues'][0] == 'kta.example.com'

--- a/tests/test_rfc6120.py
+++ b/tests/test_rfc6120.py
@@ -8,8 +8,9 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
+from pyasn1.compat.octets import str2octs
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5280
@@ -41,58 +42,70 @@ nOzhcMpnHs2U/eN0lHl/JNgnbftl6Dvnt59xdA==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.xmpp_server_cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         count = 0
+
         for extn in asn1Object['tbsCertificate']['extensions']:
             if extn['extnID'] == rfc5280.id_ce_subjectAltName:
-                extnValue, rest = der_decode(extn['extnValue'],
-                    asn1Spec=rfc5280.SubjectAltName())
-                assert not rest
-                assert extnValue.prettyPrint()
-                assert der_encode(extnValue) == extn['extnValue']
+                extnValue, rest = der_decoder(
+                    extn['extnValue'], asn1Spec=rfc5280.SubjectAltName())
+
+                self.assertFalse(rest)
+                self.assertTrue(extnValue.prettyPrint())
+                self.assertEqual(extn['extnValue'], der_encoder(extnValue))
+
                 for gn in extnValue:
                     if gn['otherName'].hasValue():
                         gn_on = gn['otherName']
                         if gn_on['type-id'] == rfc6120.id_on_xmppAddr:
-                            assert gn_on['type-id'] in rfc5280.anotherNameMap.keys()
+                            self.assertIn(gn_on['type-id'], rfc5280.anotherNameMap)
+
                             spec = rfc5280.anotherNameMap[gn['otherName']['type-id']]
-                            on, rest = der_decode(gn_on['value'], asn1Spec=spec)
-                            assert not rest
-                            assert on.prettyPrint()
-                            assert der_encode(on) == gn_on['value']
-                            assert on == u'im.example.com'
+                            on, rest = der_decoder(gn_on['value'], asn1Spec=spec)
+
+                            self.assertFalse(rest)
+                            self.assertTrue(on.prettyPrint())
+                            self.assertEqual(gn_on['value'], der_encoder(on))
+                            self.assertEqual('im.example.com', on)
+
                             count += 1
 
-        assert count == 1
+        self.assertEqual(1, count)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.xmpp_server_cert_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate,
+                                       asn1Spec=self.asn1Spec,
+                                       decodeOpenTypes=True)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         count = 0
+
         for extn in asn1Object['tbsCertificate']['extensions']:
             if extn['extnID'] == rfc5280.id_ce_subjectAltName:
-                extnValue, rest = der_decode(extn['extnValue'],
-                    asn1Spec=rfc5280.SubjectAltName(), decodeOpenTypes=True)
-                assert not rest
-                assert extnValue.prettyPrint()
-                assert der_encode(extnValue) == extn['extnValue']
+                extnValue, rest = der_decoder(
+                    extn['extnValue'], asn1Spec=rfc5280.SubjectAltName(),
+                    decodeOpenTypes=True)
+
+                self.assertFalse(rest)
+                self.assertTrue(extnValue.prettyPrint())
+                self.assertEqual(extn['extnValue'], der_encoder(extnValue))
+
                 for gn in extnValue:
                     if gn['otherName'].hasValue():
                         if gn['otherName']['type-id'] == rfc6120.id_on_xmppAddr:
-                            assert gn['otherName']['value'] == u'im.example.com'
+                            self.assertEqual(
+                                'im.example.com', gn['otherName']['value'])
                             count += 1
 
-        assert count == 1
+        self.assertEqual(1, count)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc6187.py
+++ b/tests/test_rfc6187.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5280
@@ -43,21 +43,24 @@ voNP0ODFhhlpFo6lwVHd8Gu+6hShC2PKdAfs4QFDS9ZKgQeZ
         ]
 
         substrate = pem.readBase64fromText(self.cert_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         count = 0
+
         for extn in asn1Object['tbsCertificate']['extensions']:
             if extn['extnID'] == rfc5280.id_ce_extKeyUsage:
-                extnValue, rest = der_decode(extn['extnValue'],
-                    asn1Spec=rfc5280.ExtKeyUsageSyntax())
+                extnValue, rest = der_decoder(
+                    extn['extnValue'], asn1Spec=rfc5280.ExtKeyUsageSyntax())
+
                 for oid in extnValue:
                     if oid in ssh_eku_oids:
                         count += 1
 
-        assert count == 1
+        self.assertEqual(1, count)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc6664.py
+++ b/tests/test_rfc6664.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5480
@@ -37,51 +37,52 @@ PQMBBwYFK4EEACIGBSuBBAAjMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgEFAA==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.smime_capabilities_pem_text)
-        asn1Object, rest = der_decode (substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         count = 0
         for cap in asn1Object:
             if cap['capabilityID'] in rfc5751.smimeCapabilityMap.keys():
                 substrate = cap['parameters']
-                cap_p, rest = der_decode (substrate,
-                    asn1Spec=rfc5751.smimeCapabilityMap[cap['capabilityID']])
-                assert not rest
-                assert cap_p.prettyPrint()
-                assert der_encode(cap_p) == substrate
+                cap_p, rest = der_decoder(
+                    substrate, asn1Spec=rfc5751.smimeCapabilityMap[cap['capabilityID']])
+                self.assertFalse(rest)
+                self.assertTrue(cap_p.prettyPrint())
+                self.assertEqual(substrate, der_encoder(cap_p))
                 count += 1
 
-        assert count == 8
+        self.assertEqual(8, count)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.smime_capabilities_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         parameterValue = {
-            rfc6664.rsaEncryption:  lambda x: x['maxKeySize'],
-            rfc6664.id_RSAES_OAEP:  lambda x: x['maxKeySize'],
-            rfc6664.id_RSASSA_PSS:  lambda x: x['minKeySize'],
-            rfc6664.id_dsa:         lambda x: x['keySizes']['maxKeySize'],
+            rfc6664.rsaEncryption: lambda x: x['maxKeySize'],
+            rfc6664.id_RSAES_OAEP: lambda x: x['maxKeySize'],
+            rfc6664.id_RSASSA_PSS: lambda x: x['minKeySize'],
+            rfc6664.id_dsa: lambda x: x['keySizes']['maxKeySize'],
             rfc6664.dhpublicnumber: lambda x: x['keyParams']['q'] % 1023,
             rfc6664.id_ecPublicKey: lambda x: x[0]['namedCurve'],
-            rfc6664.id_ecMQV:       lambda x: x[1]['namedCurve'],
+            rfc6664.id_ecMQV: lambda x: x[1]['namedCurve'],
         }
 
         expectedValue = {
-            rfc6664.rsaEncryption:  4096,
-            rfc6664.id_RSAES_OAEP:  4096,
-            rfc6664.id_RSASSA_PSS:  1024,
-            rfc6664.id_dsa:         3072,
+            rfc6664.rsaEncryption: 4096,
+            rfc6664.id_RSAES_OAEP: 4096,
+            rfc6664.id_RSASSA_PSS: 1024,
+            rfc6664.id_dsa: 3072,
             rfc6664.dhpublicnumber: 257,
             rfc6664.id_ecPublicKey: rfc5480.secp256r1,
-            rfc6664.id_ecMQV:       rfc5480.secp384r1,
+            rfc6664.id_ecMQV: rfc5480.secp384r1,
         }
 
         count = 0
@@ -89,10 +90,10 @@ PQMBBwYFK4EEACIGBSuBBAAjMBoGCSqGSIb3DQEBCDANBglghkgBZQMEAgEFAA==
             if cap['capabilityID'] in parameterValue.keys():
                 pValue = parameterValue[cap['capabilityID']](cap['parameters'])
                 eValue = expectedValue[cap['capabilityID']]
-                assert pValue == eValue
+                self.assertEqual(eValue, pValue)
                 count += 1
 
-        assert count == 7
+        self.assertEqual(7, count)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc6960.py
+++ b/tests/test_rfc6960.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 from pyasn1.type import univ
 
 from pyasn1_modules import pem
@@ -29,39 +29,43 @@ isWVpesQdXMCBDXe9M+iIzAhMB8GCSsGAQUFBzABAgQSBBBjdJOiIW9EKJGELNNf/rdA
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.ocsp_req_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert asn1Object['tbsRequest']['version'] == 0
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['tbsRequest']['version'])
 
         count = 0
         for extn in asn1Object['tbsRequest']['requestExtensions']:
-            assert extn['extnID'] in rfc5280.certificateExtensionsMap.keys()
-            ev, rest = der_decode(extn['extnValue'],
+            self.assertIn(extn['extnID'], rfc5280.certificateExtensionsMap)
+
+            ev, rest = der_decoder(
+                extn['extnValue'],
                 asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
-            assert not rest
-            assert ev.prettyPrint()
-            assert der_encode(ev) == extn['extnValue']
+
+            self.assertFalse(rest)
+            self.assertTrue(ev.prettyPrint())
+            self.assertEqual(extn['extnValue'], der_encoder(ev))
+
             count += 1
 
-        assert count == 1
+        self.assertEqual(1, count)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.ocsp_req_pem_text)
-        asn1Object, rest = der_decode(substrate,
-           asn1Spec=self.asn1Spec,
-           decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        assert asn1Object['tbsRequest']['version'] == 0
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['tbsRequest']['version'])
+
         for req in  asn1Object['tbsRequest']['requestList']:
             ha = req['reqCert']['hashAlgorithm']
-            assert ha['algorithm'] == rfc4055.id_sha1
-            assert ha['parameters'] == univ.Null("")
+            self.assertEqual(rfc4055.id_sha1, ha['algorithm'])
+            self.assertEqual(univ.Null(""), ha['parameters'])
 
 
 class OCSPResponseTestCase(unittest.TestCase):
@@ -95,62 +99,74 @@ HAESdf7nebz1wtqAOXE1jWF/y8g=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.ocsp_resp_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert asn1Object['responseStatus'] == 0
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['responseStatus'])
+
         rb = asn1Object['responseBytes']
-        assert rb['responseType'] in rfc6960.ocspResponseMap.keys()
-        resp, rest = der_decode(rb['response'],
-                asn1Spec=rfc6960.ocspResponseMap[rb['responseType']])
-        assert not rest
-        assert resp.prettyPrint()
-        assert der_encode(resp) == rb['response']
 
-        resp['tbsResponseData']['version'] == 0
+        self.assertIn(rb['responseType'], rfc6960.ocspResponseMap)
+
+        resp, rest = der_decoder(
+            rb['response'], asn1Spec=rfc6960.ocspResponseMap[rb['responseType']])
+
+        self.assertFalse(rest)
+        self.assertTrue(resp.prettyPrint())
+        self.assertEqual(rb['response'], der_encoder(resp))
+        self.assertEqual(0, resp['tbsResponseData']['version'])
+
         count = 0
         for extn in resp['tbsResponseData']['responseExtensions']:
-            assert extn['extnID'] in rfc5280.certificateExtensionsMap.keys()
-            ev, rest = der_decode(extn['extnValue'],
+            self.assertIn(extn['extnID'], rfc5280.certificateExtensionsMap)
+
+            ev, rest = der_decoder(
+                extn['extnValue'],
                 asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
-            assert not rest
-            assert ev.prettyPrint()
-            assert der_encode(ev) == extn['extnValue']
+
+            self.assertFalse(rest)
+            self.assertTrue(ev.prettyPrint())
+            self.assertEqual(extn['extnValue'], der_encoder(ev))
+
             count += 1
 
-        assert count == 1
+        self.assertEqual(1, count)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.ocsp_resp_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
 
-        assert asn1Object['responseStatus'] == 0
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['responseStatus'])
+
         rb = asn1Object['responseBytes']
-        assert rb['responseType'] in rfc6960.ocspResponseMap.keys()
-        resp, rest = der_decode(rb['response'],
-                asn1Spec=rfc6960.ocspResponseMap[rb['responseType']],
-                decodeOpenTypes=True)
-        assert not rest
-        assert resp.prettyPrint()
-        assert der_encode(resp) == rb['response']
 
-        resp['tbsResponseData']['version'] == 0
+        self.assertIn(rb['responseType'], rfc6960.ocspResponseMap)
+
+        resp, rest = der_decoder(
+            rb['response'],
+            asn1Spec=rfc6960.ocspResponseMap[rb['responseType']],
+            decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(resp.prettyPrint())
+        self.assertEqual(rb['response'], der_encoder(resp))
+        self.assertEqual(0, resp['tbsResponseData']['version'])
+
         for rdn in resp['tbsResponseData']['responderID']['byName']['rdnSequence']:
             for attr in rdn:
                 if attr['type'] == rfc5280.id_emailAddress:
-                    assert attr['value'] == 'info@snmplabs.com'
+                    self.assertEqual('info@snmplabs.com', attr['value'])
 
         for r in resp['tbsResponseData']['responses']:
             ha = r['certID']['hashAlgorithm']
-            assert ha['algorithm'] == rfc4055.id_sha1
-            assert ha['parameters'] == univ.Null("")
+            self.assertEqual(rfc4055.id_sha1, ha['algorithm'])
+            self.assertEqual(univ.Null(""), ha['parameters'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc7030.py
+++ b/tests/test_rfc7030.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 from pyasn1.type import univ
 
 from pyasn1_modules import pem
@@ -23,60 +23,64 @@ MEEGCSqGSIb3DQEJBzASBgcqhkjOPQIBMQcGBSuBBAAiMBYGCSqGSIb3DQEJDjEJ
 BgcrBgEBAQEWBggqhkjOPQQDAw==
 """
 
-    the_oids = (univ.ObjectIdentifier('1.2.840.113549.1.9.7'),
-                univ.ObjectIdentifier('1.2.840.10045.4.3.3'),
+    the_oids = (
+        univ.ObjectIdentifier('1.2.840.113549.1.9.7'),
+        univ.ObjectIdentifier('1.2.840.10045.4.3.3')
     )
 
-    the_attrTypes = (univ.ObjectIdentifier('1.2.840.10045.2.1'),
-                     univ.ObjectIdentifier('1.2.840.113549.1.9.14'),
+    the_attrTypes = (
+        univ.ObjectIdentifier('1.2.840.10045.2.1'),
+        univ.ObjectIdentifier('1.2.840.113549.1.9.14'),
     )
 
-    the_attrVals = ('1.3.132.0.34',
-                    '1.3.6.1.1.1.1.22',
+    the_attrVals = (
+        '1.3.132.0.34',
+        '1.3.6.1.1.1.1.22',
     )
-
 
     def setUp(self):
         self.asn1Spec = rfc7030.CsrAttrs()
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         for attr_or_oid in asn1Object:
             if attr_or_oid.getName() == 'oid':
-                assert attr_or_oid['oid'] in self.the_oids
+                self.assertIn(attr_or_oid['oid'], self.the_oids)
 
             if attr_or_oid.getName() == 'attribute':
-                assert attr_or_oid['attribute']['attrType'] in self.the_attrTypes
+                self.assertIn(
+                    attr_or_oid['attribute']['attrType'], self.the_attrTypes)
 
     def testOpenTypes(self):
-        openTypesMap = { }
-        openTypesMap.update(rfc5652.cmsAttributesMap)
+        openTypesMap = rfc5652.cmsAttributesMap.copy()
+
         for at in self.the_attrTypes:
-            openTypesMap.update({ at: univ.ObjectIdentifier(), })
+            openTypesMap.update({at: univ.ObjectIdentifier()})
 
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            openTypes=openTypesMap,
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, openTypes=openTypesMap,
             decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         for attr_or_oid in asn1Object:
             if attr_or_oid.getName() == 'attribute':
                 valString = attr_or_oid['attribute']['attrValues'][0].prettyPrint()
-        
+
                 if attr_or_oid['attribute']['attrType'] == self.the_attrTypes[0]:
-                    assert valString == self.the_attrVals[0]
-            
+                    self.assertEqual(self.the_attrVals[0], valString)
+
                 if attr_or_oid['attribute']['attrType'] == self.the_attrTypes[1]:
-                    assert valString == self.the_attrVals[1]
+                    self.assertEqual(self.the_attrVals[1], valString)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc7296.py
+++ b/tests/test_rfc7296.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc7296
@@ -129,25 +129,29 @@ m9Y=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.cert_bundle_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         cert_count = 0
         crl_count = 0
         unk_count = 0
+
         for item in asn1Object:
             if item.getName() == 'cert':
                 cert_count += 1
+
             elif item.getName() == 'crl':
                 crl_count += 1
+
             else:
                 unk_count += 1
 
-        assert cert_count == 3
-        assert crl_count == 2
-        assert unk_count == 0
+        self.assertEqual(3, cert_count)
+        self.assertEqual(2, crl_count)
+        self.assertEqual(0, unk_count)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc7894.py
+++ b/tests/test_rfc7894.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc6402
@@ -40,36 +40,41 @@ NmaF8Y2Sl/MgvC5tjs0Ck0/r3lsoLQ==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.otp_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert asn1Object['certificationRequestInfo']['version'] == 0
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+        self.assertEqual(0, asn1Object['certificationRequestInfo']['version'])
 
         for attr in asn1Object['certificationRequestInfo']['attributes']:
-            assert attr['attrType'] in rfc6402.cmcControlAttributesMap.keys()
-            av, rest = der_decode(attr['attrValues'][0],
+            self.assertIn(
+                attr['attrType'], rfc6402.cmcControlAttributesMap)
+
+            av, rest = der_decoder(
+                attr['attrValues'][0],
                 rfc6402.cmcControlAttributesMap[attr['attrType']])
-            assert not rest
-            assert der_encode(av) == attr['attrValues'][0]
+
+            self.assertFalse(rest)
+            self.assertEqual(attr['attrValues'][0], der_encoder(av))
 
             if attr['attrType'] == rfc7894.id_aa_otpChallenge:
-                assert av['printableString'] == '90503846'
+                self.assertEqual('90503846', av['printableString'])
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.otp_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
         for attr in asn1Object['certificationRequestInfo']['attributes']:
-            assert attr['attrType'] in rfc6402.cmcControlAttributesMap.keys()
+            self.assertIn(attr['attrType'], rfc6402.cmcControlAttributesMap)
             if attr['attrType'] == rfc7894.id_aa_otpChallenge:
-                assert attr['attrValues'][0]['printableString'] == '90503846'
+                self.assertEqual(
+                    '90503846', attr['attrValues'][0]['printableString'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc8018.py
+++ b/tests/test_rfc8018.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5652
@@ -27,23 +27,29 @@ AwIHBAjv5ZjvIbM9bQQQuBslZe43PKbe3KJqF4sMEA==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.rfc3211_ex1_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
         alg_oid = asn1Object['pwri']['keyDerivationAlgorithm']['algorithm']
-        assert alg_oid == rfc8018.id_PBKDF2
+
+        self.assertEqual(rfc8018.id_PBKDF2, alg_oid)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.rfc3211_ex1_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
-        icount = asn1Object['pwri']['keyDerivationAlgorithm']['parameters']['iterationCount']
-        assert icount == 5
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        icount = (asn1Object['pwri']['keyDerivationAlgorithm']
+                            ['parameters']['iterationCount'])
+
+        self.assertEqual(5, icount)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc8103.py
+++ b/tests/test_rfc8103.py
@@ -24,15 +24,24 @@ class CAEADChaCha20Poly1305TestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.alg_id_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object[0] == rfc8103.id_alg_AEADChaCha20Poly1305
-        param, rest = der_decoder.decode(asn1Object[1], rfc8103.AEADChaCha20Poly1305Nonce())
-        assert not rest
-        assert param.prettyPrint()
-        assert param == rfc8103.AEADChaCha20Poly1305Nonce(value='\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88')
-        assert der_encoder.encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc8103.id_alg_AEADChaCha20Poly1305, asn1Object[0])
+
+        param, rest = der_decoder.decode(
+            asn1Object[1], rfc8103.AEADChaCha20Poly1305Nonce())
+
+        self.assertFalse(rest)
+        self.assertTrue(param.prettyPrint())
+        self.assertEqual(
+            rfc8103.AEADChaCha20Poly1305Nonce(value='\xca\xfe\xba\xbe\xfa'
+                                                    '\xce\xdb\xad\xde\xca'
+                                                    '\xf8\x88'),
+            param)
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc8226.py
+++ b/tests/test_rfc8226.py
@@ -17,31 +17,37 @@ from pyasn1_modules import rfc8226
 
 
 class JWTClaimConstraintsTestCase(unittest.TestCase):
-    jwtcc_pem_text = "MD2gBzAFFgNmb2+hMjAwMBkWA2ZvbzASDARmb28xDARmb28yDARmb28zMBMWA2JhcjAMDARiYXIxDARiYXIy"
+    jwtcc_pem_text = ("MD2gBzAFFgNmb2+hMjAwMBkWA2ZvbzASDARmb28xDARmb28yDARmb2"
+                      "8zMBMWA2JhcjAMDARiYXIxDARiYXIy")
 
     def setUp(self):
         self.asn1Spec = rfc8226.JWTClaimConstraints()
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.jwtcc_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 class TNAuthorizationListTestCase(unittest.TestCase):
-    tnal_pem_text = "MCugBxYFYm9ndXOhEjAQFgo1NzE1NTUxMjEyAgIDFKIMFgo3MDM1NTUxMjEy"
+    tnal_pem_text = ("MCugBxYFYm9ndXOhEjAQFgo1NzE1NTUxMjEyAgIDFKIMFgo3MDM1NTU"
+                     "xMjEy")
 
     def setUp(self):
         self.asn1Spec = rfc8226.TNAuthorizationList()
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.tnal_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 class CertificateOpenTypesTestCase(unittest.TestCase):
@@ -67,23 +73,28 @@ yEFWA6G95b/HbtPMTjLpPKtrOjhofc4LyVCDYhFhKzpvHh1qeA==
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.cert_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
 
-        extn_list = [ ]
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+
+        extn_list = []
         for extn in asn1Object['tbsCertificate']['extensions']:
             extn_list.append(extn['extnID'])
             if extn['extnID'] in rfc5280.certificateExtensionsMap.keys():
-                extnValue, rest = der_decoder.decode(extn['extnValue'],
+                extnValue, rest = der_decoder.decode(
+                    extn['extnValue'],
                     asn1Spec=rfc5280.certificateExtensionsMap[extn['extnID']])
-                assert der_encoder.encode(extnValue) == extn['extnValue']
+
+                self.assertEqual(
+                    extn['extnValue'], der_encoder.encode(extnValue))
 
                 if extn['extnID'] == rfc8226.id_pe_TNAuthList:
-                    assert extnValue[0]['spc'] == 'fake'
+                    self.assertEqual('fake', extnValue[0]['spc'])
 
-        assert rfc8226.id_pe_TNAuthList in extn_list
+        self.assertIn(rfc8226.id_pe_TNAuthList, extn_list)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc8410.py
+++ b/tests/test_rfc8410.py
@@ -17,7 +17,8 @@ from pyasn1_modules import rfc8410
 
 
 class PrivateKeyTestCase(unittest.TestCase):
-    no_pub_key_pem_text = "MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC"
+    no_pub_key_pem_text = ("MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwo"
+                           "y/HU++CXqI9EdVhC")
 
     def setUp(self):
         self.asn1Spec = rfc5208.PrivateKeyInfo()
@@ -25,12 +26,15 @@ class PrivateKeyTestCase(unittest.TestCase):
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.no_pub_key_pem_text)
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object['privateKeyAlgorithm']['algorithm'] == rfc8410.id_Ed25519
-        assert asn1Object['privateKey'].isValue
-        assert asn1Object['privateKey'].prettyPrint()[0:10] == "0x0420d4ee"
-        assert der_encoder.encode(asn1Object) == substrate
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(
+            rfc8410.id_Ed25519, asn1Object['privateKeyAlgorithm']['algorithm'])
+        self.assertTrue(asn1Object['privateKey'].isValue)
+        self.assertEqual(
+            "0x0420d4ee", asn1Object['privateKey'].prettyPrint()[0:10])
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc8418.py
+++ b/tests/test_rfc8418.py
@@ -24,12 +24,16 @@ class KeyAgreeAlgTestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.key_agree_alg_id_pem_text)
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object['algorithm'] == rfc8418.dhSinglePass_stdDH_hkdf_sha384_scheme
-        assert asn1Object['parameters'].isValue
-        assert der_encoder.encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(
+            rfc8418.dhSinglePass_stdDH_hkdf_sha384_scheme,
+            asn1Object['algorithm'])
+        self.assertTrue(asn1Object['parameters'].isValue)
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc8419.py
+++ b/tests/test_rfc8419.py
@@ -8,8 +8,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc5280
@@ -24,12 +24,13 @@ class Ed25519TestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.alg_id_1_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object['algorithm'] == rfc8419.id_Ed25519
-        assert not asn1Object['parameters'].isValue
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc8419.id_Ed25519, asn1Object['algorithm'])
+        self.assertFalse(asn1Object['parameters'].isValue)
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 class Ed448TestCase(unittest.TestCase):
@@ -40,12 +41,14 @@ class Ed448TestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.alg_id_2_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object['algorithm'] == rfc8419.id_Ed448
-        assert not asn1Object['parameters'].isValue
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc8419.id_Ed448, asn1Object['algorithm'])
+        self.assertFalse(asn1Object['parameters'].isValue)
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 class SHA512TestCase(unittest.TestCase):
@@ -56,12 +59,14 @@ class SHA512TestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.alg_id_3_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object['algorithm'] == rfc8419.id_sha512
-        assert not asn1Object['parameters'].isValue
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc8419.id_sha512, asn1Object['algorithm'])
+        self.assertFalse(asn1Object['parameters'].isValue)
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 class SHAKE256TestCase(unittest.TestCase):
@@ -72,12 +77,13 @@ class SHAKE256TestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.alg_id_4_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object['algorithm'] == rfc8419.id_shake256
-        assert not asn1Object['parameters'].isValue
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc8419.id_shake256, asn1Object['algorithm'])
+        self.assertFalse(asn1Object['parameters'].isValue)
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 class SHAKE256LENTestCase(unittest.TestCase):
@@ -88,30 +94,33 @@ class SHAKE256LENTestCase(unittest.TestCase):
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.alg_id_5_pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object['algorithm'] == rfc8419.id_shake256_len
-        assert asn1Object['parameters'].isValue
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        param, rest = der_decode(asn1Object['parameters'],
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc8419.id_shake256_len, asn1Object['algorithm'])
+        self.assertTrue(asn1Object['parameters'].isValue)
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        param, rest = der_decoder(
+            asn1Object['parameters'],
             asn1Spec=rfc5280.algorithmIdentifierMap[asn1Object['algorithm']])
-        assert not rest
-        assert param.prettyPrint()
-        assert der_encode(param) == asn1Object['parameters']
-        assert param == 512
+
+        self.assertFalse(rest)
+        self.assertTrue(param.prettyPrint())
+        self.assertEqual(asn1Object['parameters'], der_encoder(param))
+        self.assertEqual(512, param)
 
     def testOpenTypes(self):
         substrate = pem.readBase64fromText(self.alg_id_5_pem_text)
-        asn1Object, rest = der_decode(substrate,
-            asn1Spec=self.asn1Spec,
-            decodeOpenTypes=True)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert asn1Object['algorithm'] == rfc8419.id_shake256_len
-        assert asn1Object['parameters'] == 512
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(
+            substrate, asn1Spec=self.asn1Spec, decodeOpenTypes=True)
+
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(rfc8419.id_shake256_len, asn1Object['algorithm'])
+        self.assertEqual(512, asn1Object['parameters'])
+        self.assertEqual(substrate, der_encoder(asn1Object))
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc8494.py
+++ b/tests/test_rfc8494.py
@@ -7,8 +7,8 @@
 import sys
 import unittest
 
-from pyasn1.codec.der.decoder import decode as der_decode
-from pyasn1.codec.der.encoder import encode as der_encode
+from pyasn1.codec.der.decoder import decode as der_decoder
+from pyasn1.codec.der.encoder import encode as der_encoder
 
 from pyasn1_modules import pem
 from pyasn1_modules import rfc8494
@@ -31,15 +31,21 @@ EiIPVQPtvBuLBxjW5qx3TbXXo6vHJ1OhhLY=
 
     def testDerCodec(self):
         substrate = pem.readBase64fromText(self.pem_text)
-        asn1Object, rest = der_decode(substrate, asn1Spec=self.asn1Spec)
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encode(asn1Object) == substrate
+        asn1Object, rest = der_decoder(substrate, asn1Spec=self.asn1Spec)
 
-        assert asn1Object['compressionAlgorithm']['algorithmID-ShortForm'] == 0
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder(asn1Object))
+
+        self.assertEqual(
+            0, asn1Object['compressionAlgorithm']['algorithmID-ShortForm'])
+
         cci = asn1Object['compressedContentInfo']
-        assert cci['unnamed']['contentType-ShortForm'] == 25
-        assert cci['compressedContent'].prettyPrint()[:12] == '0x789c6d8fd1'
+
+        self.assertEqual(
+            25, cci['unnamed']['contentType-ShortForm'])
+        self.assertEqual(
+            '0x789c6d8fd1', cci['compressedContent'].prettyPrint()[:12])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc8619.py
+++ b/tests/test_rfc8619.py
@@ -24,14 +24,15 @@ class HKDFSHA256TestCase(unittest.TestCase):
     def testDerCodec(self):
 
         substrate = pem.readBase64fromText(self.alg_id_1_pem_text)
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        
-        assert asn1Object['algorithm'] == rfc8619.id_alg_hkdf_with_sha256
+        self.assertEqual(
+            rfc8619.id_alg_hkdf_with_sha256, asn1Object['algorithm'])
 
 
 class HKDFSHA384TestCase(unittest.TestCase):
@@ -43,14 +44,13 @@ class HKDFSHA384TestCase(unittest.TestCase):
     def testDerCodec(self):
 
         substrate = pem.readBase64fromText(self.alg_id_1_pem_text)
-
         asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        
-        assert asn1Object['algorithm'] == rfc8619.id_alg_hkdf_with_sha384
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertEqual(
+            rfc8619.id_alg_hkdf_with_sha384, asn1Object['algorithm'])
 
 
 class HKDFSHA512TestCase(unittest.TestCase):
@@ -63,13 +63,14 @@ class HKDFSHA512TestCase(unittest.TestCase):
 
         substrate = pem.readBase64fromText(self.alg_id_1_pem_text)
 
-        asn1Object, rest = der_decoder.decode(substrate, asn1Spec=self.asn1Spec)
+        asn1Object, rest = der_decoder.decode(
+            substrate, asn1Spec=self.asn1Spec)
 
-        assert not rest
-        assert asn1Object.prettyPrint()
-        assert der_encoder.encode(asn1Object) == substrate
-        
-        assert asn1Object['algorithm'] == rfc8619.id_alg_hkdf_with_sha512
+        self.assertFalse(rest)
+        self.assertTrue(asn1Object.prettyPrint())
+        self.assertEqual(substrate, der_encoder.encode(asn1Object))
+        self.assertEqual(
+            rfc8619.id_alg_hkdf_with_sha512, asn1Object['algorithm'])
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
Changed assertion in unit tests from Python built-in to `unittest`
provided. The motivation is to have better reporting on test failures.