### PR TITLE
Add WithComponentsConstraints to RFC 3739

### DIFF
--- a/pyasn1_modules/rfc3739.py
+++ b/pyasn1_modules/rfc3739.py
@@ -2,6 +2,8 @@
 # This file is part of pyasn1-modules software.
 #
 # Created by Russ Housley with assistance from asn1ate v.0.6.0.
+# Modified by Russ Housley to add WithComponentsConstraints to
+#   enforce the requirements that are indicated in comments.
 #
 # Copyright (c) 2019, Vigil Security, LLC
 # License: http://snmplabs.com/pyasn1/license.html
@@ -157,6 +159,12 @@ class SemanticsInformation(univ.Sequence):
             univ.ObjectIdentifier()),
         namedtype.OptionalNamedType('nameRegistrationAuthorities',
             NameRegistrationAuthorities())
+    )
+    subtypeSpec = constraint.ConstraintsUnion(
+        constraint.WithComponentsConstraint(
+            ('semanticsIndentifier', constraint.ComponentPresentConstraint())),
+        constraint.WithComponentsConstraint(
+            ('nameRegistrationAuthorities', constraint.ComponentPresentConstraint()))
     )
 
 

--- a/tests/test_rfc3739.py
+++ b/tests/test_rfc3739.py
@@ -115,15 +115,8 @@ Iwtui+Wql/HveMqbAtXkiv9GDXYZms3HBoIaCVuDaUf6
 class WithComponentsTestCase(unittest.TestCase):
 
     def testDerCodec(self):
-
-        try:
-            si = rfc3739.SemanticsInformation()
-            substrate = der_encoder(si)
-            encode_without_error = True
-        except error.PyAsn1Error:
-            encode_without_error = False
-
-        self.assertFalse(encode_without_error)
+        si = rfc3739.SemanticsInformation()
+        self.assertRaises(error.PyAsn1Error, der_encoder, si)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])

--- a/tests/test_rfc3739.py
+++ b/tests/test_rfc3739.py
@@ -10,6 +10,7 @@ import unittest
 from pyasn1.codec.der.decoder import decode as der_decoder
 from pyasn1.codec.der.encoder import encode as der_encoder
 
+from pyasn1.type import error
 from pyasn1.type import univ
 
 from pyasn1_modules import pem
@@ -110,6 +111,19 @@ Iwtui+Wql/HveMqbAtXkiv9GDXYZms3HBoIaCVuDaUf6
 
         self.assertEqual(2, count)
         self.assertTrue(found_qc_stmt_oid)
+
+class WithComponentsTestCase(unittest.TestCase):
+
+    def testDerCodec(self):
+
+        try:
+            si = rfc3739.SemanticsInformation()
+            substrate = der_encoder(si)
+            encode_without_error = True
+        except error.PyAsn1Error:
+            encode_without_error = False
+
+        self.assertFalse(encode_without_error)
 
 
 suite = unittest.TestLoader().loadTestsFromModule(sys.modules[__name__])


### PR DESCRIPTION
Add WithComponentsConstraints to enforce the requirements that are indicated by comments in the ASN.1 module.