### PR TITLE
Correct imports in the RFC 4683 module

### DIFF
--- a/pyasn1_modules/rfc4683.py
+++ b/pyasn1_modules/rfc4683.py
@@ -13,7 +13,9 @@
 # https://www.rfc-editor.org/errata/eid1047
 #
 
-from pyasn1.type import univ, char, namedtype, namedval, tag, constraint, useful
+from pyasn1.type import char
+from pyasn1.type import namedtype
+from pyasn1.type import univ
 
 from pyasn1_modules import rfc5280
 


### PR DESCRIPTION
Trim the asn1ate imports to the ones that are actually needed