### PR TITLE
Fix mapping for CRLNumber value type

### DIFF
--- a/pyasn1_modules/rfc5280.py
+++ b/pyasn1_modules/rfc5280.py
@@ -1646,7 +1646,7 @@ _certificateExtensionsMap = {
     id_ce_extKeyUsage: ExtKeyUsageSyntax(),
     id_ce_cRLDistributionPoints: CRLDistributionPoints(),
     id_pe_authorityInfoAccess: AuthorityInfoAccessSyntax(),
-    id_ce_cRLNumber: univ.Integer(),
+    id_ce_cRLNumber: CRLNumber(),
     id_ce_deltaCRLIndicator: BaseCRLNumber(),
     id_ce_issuingDistributionPoint: IssuingDistributionPoint(),
     id_ce_cRLReasons: CRLReason(),


### PR DESCRIPTION
The value type of the CRLNumber CRL extension in RFC 5280 is defined as CRLNumber, not INTEGER (CRLNumber has a constraint to prohibit negative values).